### PR TITLE
Refactor execution

### DIFF
--- a/crates/pjsh_ast/src/lib.rs
+++ b/crates/pjsh_ast/src/lib.rs
@@ -18,6 +18,12 @@ pub struct Assignment {
     pub value: Word,
 }
 
+impl Assignment {
+    pub fn new(key: Word, value: Word) -> Self {
+        Self { key, value }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Word {
     Literal(String),

--- a/crates/pjsh_builtins/src/exit.rs
+++ b/crates/pjsh_builtins/src/exit.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pjsh_core::{Context, InternalCommand, InternalIo};
+
+const EXIT_INVALID_CODE: i32 = 128;
+
+pub struct Exit;
+
+impl InternalCommand for Exit {
+    fn name(&self) -> &str {
+        "exit"
+    }
+
+    fn run(&self, args: &[String], ctx: Arc<Mutex<Context>>, io: Arc<Mutex<InternalIo>>) -> i32 {
+        match args {
+            [] => ctx.lock().last_exit,
+            [n] => n.parse::<i32>().unwrap_or(EXIT_INVALID_CODE),
+            _ => {
+                let _ = writeln!(io.lock().stderr, "exit: too many arguments");
+                1
+            }
+        }
+    }
+}

--- a/crates/pjsh_builtins/src/lib.rs
+++ b/crates/pjsh_builtins/src/lib.rs
@@ -1,11 +1,13 @@
 mod alias;
 mod drop;
 mod echo;
+mod exit;
 mod fs;
 
 pub use alias::{Alias, Unalias};
 pub use drop::Drop;
 pub use echo::Echo;
+pub use exit::Exit;
 pub use fs::{Cd, Pwd};
 
 pub fn builtin(name: &str) -> Option<Box<dyn pjsh_core::InternalCommand>> {
@@ -14,6 +16,7 @@ pub fn builtin(name: &str) -> Option<Box<dyn pjsh_core::InternalCommand>> {
         "cd" => Some(Box::new(Cd {})),
         "drop" => Some(Box::new(Drop {})),
         "echo" => Some(Box::new(Echo {})),
+        "exit" => Some(Box::new(Exit {})),
         "pwd" => Some(Box::new(Pwd {})),
         "unalias" => Some(Box::new(Unalias {})),
         _ => None,

--- a/crates/pjsh_exec/src/exit.rs
+++ b/crates/pjsh_exec/src/exit.rs
@@ -1,0 +1,5 @@
+/// Status code for a successful exit.
+pub(crate) const EXIT_SUCCESS: i32 = 0;
+
+/// Catch-all status code for general errors.
+pub(crate) const EXIT_GENERAL_ERROR: i32 = 1;

--- a/crates/pjsh_exec/src/lib.rs
+++ b/crates/pjsh_exec/src/lib.rs
@@ -1,8 +1,12 @@
 mod error;
 mod executor;
+mod exit;
 mod expand;
 mod io;
 mod word;
+
+#[cfg(test)]
+mod tests;
 
 pub use executor::Executor;
 pub use expand::expand;

--- a/crates/pjsh_exec/src/tests/and_or.rs
+++ b/crates/pjsh_exec/src/tests/and_or.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use pjsh_ast::{AndOr, AndOrOp, Command, Pipeline, PipelineSegment, Word};
+use pjsh_core::Context;
+
+use crate::Executor;
+
+fn pipeline(exit_status: i32) -> Pipeline {
+    Pipeline {
+        is_async: false,
+        segments: vec![PipelineSegment {
+            command: Command {
+                program: Word::Literal("exit".into()),
+                arguments: vec![Word::Literal(format!("{}", exit_status))],
+                redirects: Vec::new(),
+            },
+        }],
+    }
+}
+
+#[test]
+fn execute_and_success() {
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = Executor;
+    let and_success = AndOr {
+        operators: vec![AndOrOp::And],
+        pipelines: vec![pipeline(0), pipeline(0)],
+    };
+    executor.execute_and_or(and_success, Arc::clone(&ctx));
+    assert_eq!(ctx.lock().last_exit, 0);
+}
+
+#[test]
+fn execute_and_fail() {
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = Executor;
+    let and_success = AndOr {
+        operators: vec![AndOrOp::And],
+        pipelines: vec![pipeline(1), pipeline(0)],
+    };
+    executor.execute_and_or(and_success, Arc::clone(&ctx));
+    assert_eq!(ctx.lock().last_exit, 1);
+}
+
+#[test]
+fn execute_or_first_success() {
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = Executor;
+    let and_success = AndOr {
+        operators: vec![AndOrOp::Or],
+        pipelines: vec![pipeline(0), pipeline(1)],
+    };
+    executor.execute_and_or(and_success, Arc::clone(&ctx));
+    assert_eq!(ctx.lock().last_exit, 0);
+}
+
+#[test]
+fn execute_or_last_success() {
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = Executor;
+    let and_success = AndOr {
+        operators: vec![AndOrOp::Or],
+        pipelines: vec![pipeline(1), pipeline(0)],
+    };
+    executor.execute_and_or(and_success, Arc::clone(&ctx));
+    assert_eq!(ctx.lock().last_exit, 0);
+}
+
+#[test]
+fn execute_or_last_fail() {
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = Executor;
+    let and_success = AndOr {
+        operators: vec![AndOrOp::Or],
+        pipelines: vec![pipeline(1), pipeline(1)],
+    };
+    executor.execute_and_or(and_success, Arc::clone(&ctx));
+    assert_eq!(ctx.lock().last_exit, 1);
+}

--- a/crates/pjsh_exec/src/tests/mod.rs
+++ b/crates/pjsh_exec/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod and_or;

--- a/crates/pjsh_exec/src/tests/mod.rs
+++ b/crates/pjsh_exec/src/tests/mod.rs
@@ -1,1 +1,2 @@
 mod and_or;
+mod statement;

--- a/crates/pjsh_exec/src/tests/statement.rs
+++ b/crates/pjsh_exec/src/tests/statement.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use pjsh_ast::{Assignment, Statement, Word};
+use pjsh_core::Context;
+
+use crate::Executor;
+
+#[test]
+fn execute_assign() {
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = Executor;
+    let assignment = Assignment::new(Word::Literal("key".into()), Word::Literal("value".into()));
+
+    executor.execute_statement(Statement::Assignment(assignment), Arc::clone(&ctx));
+
+    assert_eq!(ctx.lock().scope.get_env("key"), Some("value".into()));
+}
+
+#[test]
+fn execute_assign_replace() {
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = Executor;
+    let assignment = Assignment::new(Word::Literal("key".into()), Word::Literal("new".into()));
+
+    ctx.lock().scope.set_env("key".into(), "old".into());
+    executor.execute_statement(Statement::Assignment(assignment), Arc::clone(&ctx));
+
+    assert_eq!(ctx.lock().scope.get_env("key"), Some("new".into()));
+}


### PR DESCRIPTION
- Register all intermediate processes and threads.
- Refactor and/or logic.
- Add simple _exit_ builtin.
- Add tests for assignments.
- Add minimal tests for and/or logic.