### PR TITLE
Update built-in commands

### DIFF
--- a/crates/pjsh/src/action/mod.rs
+++ b/crates/pjsh/src/action/mod.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pjsh_builtins::status;
+use pjsh_core::{Context, InternalCommand, InternalIo};
+use pjsh_exec::interpolate_word;
+use pjsh_parse::parse_interpolation;
+
+use crate::{exec::create_executor, run_shell, shell::file::FileBufferShell};
+
+#[derive(Clone)]
+pub(crate) struct Interpolate;
+impl InternalCommand for Interpolate {
+    fn name(&self) -> &str {
+        "interpolate"
+    }
+
+    fn run(&self, args: &[String], ctx: Arc<Mutex<Context>>, io: Arc<Mutex<InternalIo>>) -> i32 {
+        if args.is_empty() {
+            let _ = writeln!(
+                io.lock().stderr,
+                "interpolate: usage: interpolate: text [text ...]"
+            );
+            return status::BUILTIN_ERROR;
+        }
+
+        let executor = create_executor();
+        let mut exit = status::SUCCESS;
+        for arg in args {
+            let interpolated_value =
+                parse_interpolation(arg).map(|word| interpolate_word(&executor, word, &ctx.lock()));
+            match interpolated_value {
+                Ok(value) => {
+                    let _ = writeln!(io.lock().stdout, "{}", &value);
+                }
+                Err(error) => {
+                    let _ = writeln!(io.lock().stderr, "interpolate: {}", error);
+                    exit = status::GENERAL_ERROR;
+                }
+            }
+        }
+
+        exit
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Source;
+impl InternalCommand for Source {
+    fn name(&self) -> &str {
+        "source"
+    }
+
+    fn run(&self, args: &[String], ctx: Arc<Mutex<Context>>, io: Arc<Mutex<InternalIo>>) -> i32 {
+        if args.is_empty() {
+            let _ = writeln!(
+                io.lock().stderr,
+                "source: usage: source: filename [argument ...]"
+            );
+            return status::BUILTIN_ERROR;
+        }
+
+        if args.len() > 1 {
+            todo!("support arguments when sourcing files");
+        }
+
+        let script_file = args.get(0).expect("script file argument");
+        let shell = FileBufferShell::new(script_file);
+
+        run_shell(Box::new(shell), Arc::clone(&ctx));
+        ctx.lock().last_exit
+    }
+}

--- a/crates/pjsh/src/exec.rs
+++ b/crates/pjsh/src/exec.rs
@@ -1,0 +1,11 @@
+use pjsh_exec::Executor;
+
+use crate::action;
+
+/// Creates a new executor with registered actions.
+pub(crate) fn create_executor() -> Executor {
+    let mut executor = Executor::default();
+    executor.register_action(Box::new(action::Interpolate {}));
+    executor.register_action(Box::new(action::Source {}));
+    executor
+}

--- a/crates/pjsh_builtins/src/alias.rs
+++ b/crates/pjsh_builtins/src/alias.rs
@@ -5,8 +5,8 @@ use pjsh_core::{Context, InternalCommand, InternalIo};
 
 use crate::status;
 
+#[derive(Clone)]
 pub struct Alias;
-
 impl InternalCommand for Alias {
     fn name(&self) -> &str {
         "alias"
@@ -53,8 +53,8 @@ impl InternalCommand for Alias {
     }
 }
 
+#[derive(Clone)]
 pub struct Unalias;
-
 impl InternalCommand for Unalias {
     fn name(&self) -> &str {
         "unalias"

--- a/crates/pjsh_builtins/src/echo.rs
+++ b/crates/pjsh_builtins/src/echo.rs
@@ -5,8 +5,8 @@ use pjsh_core::{Context, InternalCommand, InternalIo};
 
 use crate::status;
 
+#[derive(Clone)]
 pub struct Echo;
-
 impl InternalCommand for Echo {
     fn name(&self) -> &str {
         "echo"

--- a/crates/pjsh_builtins/src/echo.rs
+++ b/crates/pjsh_builtins/src/echo.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use pjsh_core::{Context, InternalCommand, InternalIo};
 
+use crate::status;
+
 pub struct Echo;
 
 impl InternalCommand for Echo {
@@ -25,10 +27,10 @@ impl InternalCommand for Echo {
         // Use exit code to signal success. If stdout cannot be written to, stderr is probably not
         // going to work either.
         match writeln!(io.lock().stdout, "{}", &output) {
-            Ok(_) => 0,
+            Ok(_) => status::SUCCESS,
             Err(error) => {
                 let _ = writeln!(io.lock().stderr, "echo: {}", error);
-                1
+                status::GENERAL_ERROR
             }
         }
     }

--- a/crates/pjsh_builtins/src/env.rs
+++ b/crates/pjsh_builtins/src/env.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use pjsh_core::{Context, InternalCommand, InternalIo};
 
+use crate::status;
+
 pub struct Drop;
 
 impl InternalCommand for Drop {
@@ -19,13 +21,13 @@ impl InternalCommand for Drop {
     ) -> i32 {
         if args.is_empty() {
             let _ = writeln!(io.lock().stderr, "drop: missing keys to drop");
-            return 2;
+            return status::BUILTIN_ERROR;
         }
 
         for arg in args {
             context.lock().scope.unset_env(arg);
         }
 
-        0
+        status::SUCCESS
     }
 }

--- a/crates/pjsh_builtins/src/env.rs
+++ b/crates/pjsh_builtins/src/env.rs
@@ -5,8 +5,8 @@ use pjsh_core::{Context, InternalCommand, InternalIo};
 
 use crate::status;
 
+#[derive(Clone)]
 pub struct Drop;
-
 impl InternalCommand for Drop {
     fn name(&self) -> &str {
         "drop"

--- a/crates/pjsh_builtins/src/exit.rs
+++ b/crates/pjsh_builtins/src/exit.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use pjsh_core::{Context, InternalCommand, InternalIo};
 
+use crate::status;
+
 const EXIT_INVALID_CODE: i32 = 128;
 
 pub struct Exit;
@@ -18,7 +20,7 @@ impl InternalCommand for Exit {
             [n] => n.parse::<i32>().unwrap_or(EXIT_INVALID_CODE),
             _ => {
                 let _ = writeln!(io.lock().stderr, "exit: too many arguments");
-                1
+                status::BUILTIN_ERROR
             }
         }
     }

--- a/crates/pjsh_builtins/src/exit.rs
+++ b/crates/pjsh_builtins/src/exit.rs
@@ -7,8 +7,8 @@ use crate::status;
 
 const EXIT_INVALID_CODE: i32 = 128;
 
+#[derive(Clone)]
 pub struct Exit;
-
 impl InternalCommand for Exit {
     fn name(&self) -> &str {
         "exit"

--- a/crates/pjsh_builtins/src/fs.rs
+++ b/crates/pjsh_builtins/src/fs.rs
@@ -8,8 +8,8 @@ use pjsh_core::{
 
 use crate::status;
 
+#[derive(Clone)]
 pub struct Cd;
-
 impl Cd {
     fn change_directory(&self, path: PathBuf, context: &mut Context) -> bool {
         if !path.is_dir() {
@@ -90,8 +90,8 @@ impl InternalCommand for Cd {
     }
 }
 
+#[derive(Clone)]
 pub struct Pwd;
-
 impl InternalCommand for Pwd {
     fn name(&self) -> &str {
         "pwd"

--- a/crates/pjsh_builtins/src/lib.rs
+++ b/crates/pjsh_builtins/src/lib.rs
@@ -1,24 +1,19 @@
 mod alias;
-mod drop;
 mod echo;
+mod env;
 mod exit;
 mod fs;
-
-pub use alias::{Alias, Unalias};
-pub use drop::Drop;
-pub use echo::Echo;
-pub use exit::Exit;
-pub use fs::{Cd, Pwd};
+mod status;
 
 pub fn builtin(name: &str) -> Option<Box<dyn pjsh_core::InternalCommand>> {
     match name {
-        "alias" => Some(Box::new(Alias {})),
-        "cd" => Some(Box::new(Cd {})),
-        "drop" => Some(Box::new(Drop {})),
-        "echo" => Some(Box::new(Echo {})),
-        "exit" => Some(Box::new(Exit {})),
-        "pwd" => Some(Box::new(Pwd {})),
-        "unalias" => Some(Box::new(Unalias {})),
+        "alias" => Some(Box::new(alias::Alias {})),
+        "cd" => Some(Box::new(fs::Cd {})),
+        "drop" => Some(Box::new(env::Drop {})),
+        "echo" => Some(Box::new(echo::Echo {})),
+        "exit" => Some(Box::new(exit::Exit {})),
+        "pwd" => Some(Box::new(fs::Pwd {})),
+        "unalias" => Some(Box::new(alias::Unalias {})),
         _ => None,
     }
 }

--- a/crates/pjsh_builtins/src/lib.rs
+++ b/crates/pjsh_builtins/src/lib.rs
@@ -3,6 +3,7 @@ mod echo;
 mod env;
 mod exit;
 mod fs;
+mod logic;
 pub mod status;
 
 /// Returns a built-in [`InternalCommand`] with a given `name`.
@@ -13,7 +14,9 @@ pub fn builtin(name: &str) -> Option<Box<dyn pjsh_core::InternalCommand>> {
         "drop" => Some(Box::new(env::Drop {})),
         "echo" => Some(Box::new(echo::Echo {})),
         "exit" => Some(Box::new(exit::Exit {})),
+        "false" => Some(Box::new(logic::False {})),
         "pwd" => Some(Box::new(fs::Pwd {})),
+        "true" => Some(Box::new(logic::True {})),
         "unalias" => Some(Box::new(alias::Unalias {})),
         _ => None,
     }

--- a/crates/pjsh_builtins/src/lib.rs
+++ b/crates/pjsh_builtins/src/lib.rs
@@ -3,8 +3,9 @@ mod echo;
 mod env;
 mod exit;
 mod fs;
-mod status;
+pub mod status;
 
+/// Returns a built-in [`InternalCommand`] with a given `name`.
 pub fn builtin(name: &str) -> Option<Box<dyn pjsh_core::InternalCommand>> {
     match name {
         "alias" => Some(Box::new(alias::Alias {})),

--- a/crates/pjsh_builtins/src/logic.rs
+++ b/crates/pjsh_builtins/src/logic.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pjsh_core::{Context, InternalCommand, InternalIo};
+
+use crate::status;
+
+#[derive(Clone)]
+pub struct False;
+impl InternalCommand for False {
+    fn name(&self) -> &str {
+        "false"
+    }
+
+    fn run(&self, _: &[String], _: Arc<Mutex<Context>>, _: Arc<Mutex<InternalIo>>) -> i32 {
+        status::GENERAL_ERROR
+    }
+}
+
+#[derive(Clone)]
+pub struct True;
+impl InternalCommand for True {
+    fn name(&self) -> &str {
+        "true"
+    }
+
+    fn run(&self, _: &[String], _: Arc<Mutex<Context>>, _: Arc<Mutex<InternalIo>>) -> i32 {
+        status::SUCCESS
+    }
+}

--- a/crates/pjsh_builtins/src/status.rs
+++ b/crates/pjsh_builtins/src/status.rs
@@ -1,3 +1,3 @@
-pub(crate) const SUCCESS: i32 = 0;
-pub(crate) const GENERAL_ERROR: i32 = 1;
-pub(crate) const BUILTIN_ERROR: i32 = 2;
+pub const SUCCESS: i32 = 0;
+pub const GENERAL_ERROR: i32 = 1;
+pub const BUILTIN_ERROR: i32 = 2;

--- a/crates/pjsh_builtins/src/status.rs
+++ b/crates/pjsh_builtins/src/status.rs
@@ -1,0 +1,3 @@
+pub(crate) const SUCCESS: i32 = 0;
+pub(crate) const GENERAL_ERROR: i32 = 1;
+pub(crate) const BUILTIN_ERROR: i32 = 2;

--- a/crates/pjsh_exec/src/builtins/mod.rs
+++ b/crates/pjsh_exec/src/builtins/mod.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pjsh_builtins::status;
+use pjsh_core::{find_in_path, utils::path_to_string, Context, InternalCommand, InternalIo};
+
+struct Type;
+impl InternalCommand for Type {
+    fn name(&self) -> &str {
+        "type"
+    }
+
+    fn run(&self, args: &[String], ctx: Arc<Mutex<Context>>, io: Arc<Mutex<InternalIo>>) -> i32 {
+        if args.is_empty() {
+            let _ = writeln!(io.lock().stderr, "type: usage: type name [name ...]");
+            return status::BUILTIN_ERROR;
+        }
+
+        let mut exit = status::SUCCESS;
+        for arg in args {
+            if let Some(cmd) = builtin(arg) {
+                let _ = writeln!(io.lock().stdout, "{} is a shell builtin", cmd.name());
+                continue;
+            }
+
+            if let Some(alias) = ctx.lock().scope.get_alias(arg) {
+                let _ = writeln!(io.lock().stdout, "{} is aliased to `{}'", arg, alias);
+                continue;
+            }
+
+            match find_in_path(arg, &ctx.lock()) {
+                Some(path) => {
+                    let _ = writeln!(io.lock().stdout, "{} is {}", arg, path_to_string(&path));
+                }
+                None => {
+                    let path_var = ctx.lock().scope.get_env("PATH").unwrap_or_default();
+                    let _ = writeln!(io.lock().stderr, "type: no {} in ({})", &arg, path_var);
+                    exit = status::GENERAL_ERROR;
+                }
+            }
+        }
+
+        exit
+    }
+}
+
+struct Which;
+impl InternalCommand for Which {
+    fn name(&self) -> &str {
+        "which"
+    }
+
+    fn run(&self, args: &[String], ctx: Arc<Mutex<Context>>, io: Arc<Mutex<InternalIo>>) -> i32 {
+        if args.is_empty() {
+            let _ = writeln!(io.lock().stderr, "which: usage: which name [name ...]");
+            return status::BUILTIN_ERROR;
+        }
+
+        let mut exit = status::SUCCESS;
+        for arg in args {
+            match find_in_path(arg, &ctx.lock()) {
+                Some(path) => {
+                    let _ = writeln!(io.lock().stdout, "{}", path_to_string(&path));
+                }
+                None => {
+                    let path_var = ctx.lock().scope.get_env("PATH").unwrap_or_default();
+                    let _ = writeln!(io.lock().stderr, "which: no {} in ({})", &arg, path_var);
+                    exit = status::GENERAL_ERROR;
+                }
+            }
+        }
+
+        exit
+    }
+}
+
+/// Returns a built-in [`InternalCommand`] with a given `name`.
+pub fn builtin(name: &str) -> Option<Box<dyn InternalCommand>> {
+    match name {
+        "type" => Some(Box::new(Type {})),
+        "which" => Some(Box::new(Which {})),
+        name => pjsh_builtins::builtin(name),
+    }
+}

--- a/crates/pjsh_exec/src/executor.rs
+++ b/crates/pjsh_exec/src/executor.rs
@@ -9,7 +9,6 @@ use std::{
 
 use parking_lot::Mutex;
 use pjsh_ast::{AndOr, AndOrOp, Assignment, Command, Pipeline, Statement};
-use pjsh_builtins::builtin;
 use pjsh_core::{
     find_in_path,
     utils::{path_to_string, resolve_path},
@@ -18,6 +17,7 @@ use pjsh_core::{
 use tempfile::tempfile;
 
 use crate::{
+    builtins::builtin,
     error::ExecError,
     exit::{EXIT_GENERAL_ERROR, EXIT_SUCCESS},
     expand::{expand, expand_single},

--- a/crates/pjsh_exec/src/lib.rs
+++ b/crates/pjsh_exec/src/lib.rs
@@ -1,3 +1,4 @@
+mod builtins;
 mod error;
 mod executor;
 mod exit;

--- a/crates/pjsh_exec/src/tests/and_or.rs
+++ b/crates/pjsh_exec/src/tests/and_or.rs
@@ -22,7 +22,7 @@ fn pipeline(exit_status: i32) -> Pipeline {
 fn execute_and_success() {
     let mut fds = FileDescriptors::new();
     let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
-    let executor = Executor;
+    let executor = Executor::default();
     let and_success = AndOr {
         operators: vec![AndOrOp::And],
         pipelines: vec![pipeline(0), pipeline(0)],
@@ -35,7 +35,7 @@ fn execute_and_success() {
 fn execute_and_fail() {
     let mut fds = FileDescriptors::new();
     let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
-    let executor = Executor;
+    let executor = Executor::default();
     let and_success = AndOr {
         operators: vec![AndOrOp::And],
         pipelines: vec![pipeline(1), pipeline(0)],
@@ -48,7 +48,7 @@ fn execute_and_fail() {
 fn execute_or_first_success() {
     let mut fds = FileDescriptors::new();
     let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
-    let executor = Executor;
+    let executor = Executor::default();
     let and_success = AndOr {
         operators: vec![AndOrOp::Or],
         pipelines: vec![pipeline(0), pipeline(1)],
@@ -61,7 +61,7 @@ fn execute_or_first_success() {
 fn execute_or_last_success() {
     let mut fds = FileDescriptors::new();
     let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
-    let executor = Executor;
+    let executor = Executor::default();
     let and_success = AndOr {
         operators: vec![AndOrOp::Or],
         pipelines: vec![pipeline(1), pipeline(0)],
@@ -74,7 +74,7 @@ fn execute_or_last_success() {
 fn execute_or_last_fail() {
     let mut fds = FileDescriptors::new();
     let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
-    let executor = Executor;
+    let executor = Executor::default();
     let and_success = AndOr {
         operators: vec![AndOrOp::Or],
         pipelines: vec![pipeline(1), pipeline(1)],

--- a/crates/pjsh_exec/src/tests/program.rs
+++ b/crates/pjsh_exec/src/tests/program.rs
@@ -6,9 +6,12 @@ use pjsh_ast::{
 };
 use pjsh_core::Context;
 
+use crate::Executor;
+
 #[test]
 fn execute_program() {
     let ctx = Context::default();
+    let executor = Executor::default();
     let program = Program {
         statements: vec![Statement::AndOr(AndOr {
             operators: Vec::new(),
@@ -25,7 +28,8 @@ fn execute_program() {
         })],
     };
 
-    let (stdout, stderr) = crate::executor::execute_program(program, Arc::new(Mutex::new(ctx)));
+    let (stdout, stderr) =
+        crate::executor::execute_program(&executor, program, Arc::new(Mutex::new(ctx)));
 
     assert_eq!(stdout, String::from("Hello, world!\n")); // Echo adds newline.
     assert_eq!(stderr, String::new());
@@ -34,6 +38,7 @@ fn execute_program() {
 #[test]
 fn execute_program_stderr() {
     let ctx = Context::default();
+    let executor = Executor::default();
     let program = Program {
         statements: vec![Statement::AndOr(AndOr {
             operators: Vec::new(),
@@ -54,7 +59,8 @@ fn execute_program_stderr() {
         })],
     };
 
-    let (stdout, stderr) = crate::executor::execute_program(program, Arc::new(Mutex::new(ctx)));
+    let (stdout, stderr) =
+        crate::executor::execute_program(&executor, program, Arc::new(Mutex::new(ctx)));
 
     assert_eq!(stdout, String::new()); // Stdout is redirected to stderr.
     assert_eq!(stderr, String::from("Hello, world!\n")); // Echo adds newline.

--- a/crates/pjsh_exec/src/tests/statement.rs
+++ b/crates/pjsh_exec/src/tests/statement.rs
@@ -9,7 +9,7 @@ use crate::{Executor, FileDescriptors};
 fn execute_assign() {
     let mut fds = FileDescriptors::new();
     let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
-    let executor = Executor;
+    let executor = Executor::default();
     let assignment = Assignment::new(Word::Literal("key".into()), Word::Literal("value".into()));
 
     executor.execute_statement(
@@ -25,7 +25,7 @@ fn execute_assign() {
 fn execute_assign_replace() {
     let mut fds = FileDescriptors::new();
     let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
-    let executor = Executor;
+    let executor = Executor::default();
     let assignment = Assignment::new(Word::Literal("key".into()), Word::Literal("new".into()));
 
     ctx.lock().scope.set_env("key".into(), "old".into());

--- a/crates/pjsh_exec/src/word.rs
+++ b/crates/pjsh_exec/src/word.rs
@@ -4,9 +4,9 @@ use parking_lot::Mutex;
 use pjsh_ast::Word;
 use pjsh_core::Context;
 
-use crate::executor::execute_program;
+use crate::{executor::execute_program, Executor};
 
-pub fn interpolate_word(word: Word, context: &Context) -> String {
+pub fn interpolate_word(executor: &Executor, word: Word, context: &Context) -> String {
     match word {
         Word::Literal(literal) => literal,
         Word::Quoted(quoted) => quoted,
@@ -37,7 +37,7 @@ pub fn interpolate_word(word: Word, context: &Context) -> String {
                     }
                     pjsh_ast::InterpolationUnit::Subshell(program) => {
                         let inner_context = Arc::new(Mutex::new(context.fork()));
-                        output.push_str(&execute_program(program, inner_context).0)
+                        output.push_str(&execute_program(executor, program, inner_context).0)
                     }
                 }
             }
@@ -46,7 +46,7 @@ pub fn interpolate_word(word: Word, context: &Context) -> String {
         }
         Word::Subshell(program) => {
             let inner_context = Arc::new(Mutex::new(context.fork()));
-            execute_program(program, inner_context).0
+            execute_program(executor, program, inner_context).0
         }
     }
 }


### PR DESCRIPTION
Major refactor of functionality relating to built-in commands:
- Separate built-ins across crates.
- Add internal actions for built-ins that must be injected from _main_.
- Add _interpolate_ built-in.
- Add _source_ built-in.
- Add _true_ built-in.
- Add _false_ built-in.