### PR TITLE
[#20] Replace interpolated string syntax

### DIFF
--- a/crates/pjsh_parse/src/lex/lexer.rs
+++ b/crates/pjsh_parse/src/lex/lexer.rs
@@ -143,6 +143,7 @@ impl<'a> Lexer<'a> {
             "]" => self.eat_char(CloseBracket),
             "\"" => self.eat_quoted_string("\""),
             "'" => self.eat_quoted_string("'"),
+            "`" => self.eat_interpolation(Some("`")),
             "$" => self.eat_expandable(),
             ":" => self.eat_assign_or_literal(),
             "-" => self.eat_pipeline_start_or_literal(),
@@ -341,8 +342,6 @@ impl<'a> Lexer<'a> {
         let span_start = self.input.next().0;
 
         let result = match self.input.peek().1 {
-            "\"" => self.eat_interpolation(Some("\"")),
-            "'" => self.eat_interpolation(Some("'")),
             "(" => self.eat_char(OpenParen),
             _ => self.eat_variable(),
         };

--- a/crates/pjsh_parse/src/lex/tests.rs
+++ b/crates/pjsh_parse/src/lex/tests.rs
@@ -89,14 +89,14 @@ fn lex_variable() {
 #[test]
 fn lex_interpolation_token() {
     assert_eq!(
-        tokens(r#"$"literal $variable literal""#),
+        tokens("`literal $variable literal`"),
         vec![Token::new(
             Interpolation(vec![
                 InterpolationUnit::Literal("literal ".into()),
                 InterpolationUnit::Variable("variable".into()),
                 InterpolationUnit::Literal(" literal".into()),
             ]),
-            Span::new(0, 28)
+            Span::new(0, 27)
         )]
     );
 }

--- a/crates/pjsh_parse/src/parse/tests.rs
+++ b/crates/pjsh_parse/src/parse/tests.rs
@@ -471,7 +471,7 @@ fn parse_subshell() {
 #[test]
 fn parse_subshell_interpolation() {
     assert_eq!(
-        crate::parse("echo $\"today: $(date)\""),
+        crate::parse("echo `today: $(date)`"),
         Ok(Program {
             statements: vec![Statement::AndOr(AndOr {
                 operators: Vec::new(),


### PR DESCRIPTION
Replaces $"..." with `...` for interpolated strings.

Closes #20.