### PR TITLE
[#24] Replace .tar build with .tar.gz build

### DIFF
--- a/build/build-linux-packages.sh
+++ b/build/build-linux-packages.sh
@@ -70,3 +70,6 @@ package() {
 package "deb" "alanfranz/fpm-within-docker:debian-bullseye"
 package "rpm" "alanfranz/fpm-within-docker:centos-8"
 package "tar" "alanfranz/fpm-within-docker:debian-bullseye"
+
+# Compress the built .tar archive to a .tar.gz file using gzip.
+find "${PACKAGE_PATH}" -name "*.tar" -exec gzip -v9 {} \;

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -2,12 +2,12 @@
 
 _PJSH_ is built for _Linux_ and _Windows_. There is currently no build for _macOS_.
 
-| Description          | Download link |
-| :------------------- | :------------ |
-| Windows installer    | TBA           |
-| Linux (.deb) package | TBA           |
-| Linux (.rpm) package | TBA           |
-| Linux (.tar)         | TBA           |
+| Description             | Download link |
+| :---------------------- | :------------ |
+| Windows installer       | TBA           |
+| Linux (.deb) package    | TBA           |
+| Linux (.rpm) package    | TBA           |
+| Linux (.tar.gz) archive | TBA           |
 
 ## Installing From Source Code
 


### PR DESCRIPTION
Closes #24.