### PR TITLE
[#9] Update file completions

### DIFF
--- a/crates/pjsh/src/action/mod.rs
+++ b/crates/pjsh/src/action/mod.rs
@@ -7,7 +7,7 @@ use pjsh_core::{Context, InternalCommand, InternalIo};
 use pjsh_exec::interpolate_word;
 use pjsh_parse::parse_interpolation;
 
-use crate::{exec::create_executor, run_shell, shell::file::FileBufferShell};
+use crate::{exec::create_executor, file_shell::FileBufferShell, run_shell};
 
 #[derive(Clone)]
 pub(crate) struct Interpolate;

--- a/crates/pjsh/src/command_shell/mod.rs
+++ b/crates/pjsh/src/command_shell/mod.rs
@@ -1,4 +1,4 @@
-use super::{Shell, ShellInput};
+use crate::shell::{Shell, ShellInput};
 
 pub struct SingleCommandShell {
     it: Option<String>,

--- a/crates/pjsh/src/completion/complete.rs
+++ b/crates/pjsh/src/completion/complete.rs
@@ -1,0 +1,7 @@
+/// Attempts to complete input by making suggestions.
+pub trait Complete {
+    /// Completes some input.
+    ///
+    /// Returns a [`Vec<String>`] of possible completions.
+    fn complete(&self, input: &str) -> Vec<String>;
+}

--- a/crates/pjsh/src/completion/fs.rs
+++ b/crates/pjsh/src/completion/fs.rs
@@ -1,0 +1,81 @@
+use std::{
+    env::current_dir,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use dirs::home_dir;
+
+use super::Complete;
+
+const PATH_SEPARATOR: char = '/';
+
+pub struct FileCompleter;
+impl Complete for FileCompleter {
+    fn complete(&self, input: &str) -> Vec<String> {
+        let (dir_name, file_name) = match input.rfind(PATH_SEPARATOR) {
+            Some(idx) => input.split_at(idx + PATH_SEPARATOR.len_utf8()),
+            None => ("", input),
+        };
+
+        let path = base_path(dir_name);
+        files_in_path(path, dir_name, file_name)
+    }
+}
+
+fn base_path(directory: impl AsRef<Path>) -> PathBuf {
+    let dir_path = directory.as_ref();
+    if dir_path.starts_with("~") {
+        // The path is relative to the user's home directory.
+        if let Some(home) = home_dir() {
+            match dir_path.strip_prefix("~") {
+                Ok(rel_path) => home.join(rel_path),
+                _ => home,
+            }
+        } else {
+            // The user does not have a known home directory. The path is not likely to work,
+            // but the autocomplete function should not throw any errors.
+            dir_path.to_path_buf()
+        }
+    } else if dir_path.is_relative() {
+        // The path is relative to the current directory.
+        if let Ok(working_directory) = current_dir() {
+            working_directory.join(dir_path)
+        } else {
+            // The current directory cannot be accessed. The path is not likely to work, but the
+            // autocomplete function should not throw any errors.
+            dir_path.to_path_buf()
+        }
+    } else {
+        // The path is absolute.
+        dir_path.to_path_buf()
+    }
+}
+
+fn files_in_path(path: PathBuf, dir_name: &str, file_name: &str) -> Vec<String> {
+    if !path.exists() {
+        return Vec::new();
+    }
+
+    let mut files: Vec<String> = Vec::new();
+
+    if let Ok(read_dir) = path.read_dir() {
+        for entry in read_dir.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                if name.starts_with(file_name) {
+                    if let Ok(metadata) = fs::metadata(entry.path()) {
+                        let mut path = String::from(dir_name) + name;
+
+                        if metadata.is_dir() {
+                            path.push(PATH_SEPARATOR);
+                        }
+
+                        files.push(path);
+                    }
+                }
+            }
+        }
+    }
+
+    files
+}

--- a/crates/pjsh/src/completion/mod.rs
+++ b/crates/pjsh/src/completion/mod.rs
@@ -1,0 +1,5 @@
+mod complete;
+mod fs;
+
+pub use complete::Complete;
+pub use fs::FileCompleter;

--- a/crates/pjsh/src/file_shell/mod.rs
+++ b/crates/pjsh/src/file_shell/mod.rs
@@ -4,7 +4,7 @@ use std::{
     path::Path,
 };
 
-use super::{Shell, ShellInput};
+use crate::shell::{Shell, ShellInput};
 
 pub struct FileBufferShell {
     reader: BufReader<fs::File>,

--- a/crates/pjsh/src/interactive_shell/complete.rs
+++ b/crates/pjsh/src/interactive_shell/complete.rs
@@ -1,0 +1,86 @@
+use rustyline::completion::{Candidate, Completer, Pair};
+
+use crate::completion::Complete;
+
+const WORD_BOUNDARY: [char; 11] = [
+    // '(',
+    // ')',
+    // '{',
+    // '}',
+    // '[',
+    // ']',
+    '\u{0009}', // \t
+    '\u{000A}', // \n
+    '\u{000B}', // vertical tab
+    '\u{000C}', // form feed
+    '\u{000D}', // \r
+    '\u{0020}', // space
+    // NEXT LINE from latin1
+    '\u{0085}', // Bidi markers
+    '\u{200E}', // LEFT-TO-RIGHT MARK
+    '\u{200F}', // RIGHT-TO-LEFT MARK
+    // Dedicated whitespace characters from Unicode
+    '\u{2028}', // LINE SEPARATOR
+    '\u{2029}', // PARAGRAPH SEPARATOR
+];
+
+pub struct CombinationCompleter {
+    completers: Vec<Box<dyn Complete>>,
+}
+
+impl CombinationCompleter {
+    pub fn new(completers: Vec<Box<dyn Complete>>) -> Self {
+        Self { completers }
+    }
+}
+
+impl Completer for CombinationCompleter {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &rustyline::Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        let start_index = line
+            .char_indices()
+            .rev()
+            .skip(line.len() - pos)
+            .find(|(_, ch)| WORD_BOUNDARY.contains(ch))
+            .map(|(index, _)| index + 1)
+            .unwrap_or(0);
+
+        let current_word = unquote(&line[start_index..pos]);
+
+        let mut completions = Vec::new();
+        for completer in &self.completers {
+            for completion in completer.complete(current_word) {
+                let quoted = quote(completion);
+                completions.push(Pair {
+                    display: quoted.clone(),
+                    replacement: quoted,
+                });
+            }
+        }
+
+        completions.sort_by(|a, b| a.display().cmp(b.display()));
+
+        Ok((start_index, completions))
+    }
+}
+
+fn quote(path: String) -> String {
+    if !path.contains(char::is_whitespace) {
+        return path;
+    }
+
+    format!("`{}`", path)
+}
+
+fn unquote(path: &str) -> &str {
+    let should_trim = |ch: char| ch.is_whitespace() || ch == '`';
+    let mut path = path.trim_end_matches(should_trim);
+    path = path.trim_start_matches(should_trim);
+    path
+}

--- a/crates/pjsh/src/interactive_shell/utils.rs
+++ b/crates/pjsh/src/interactive_shell/utils.rs
@@ -1,0 +1,14 @@
+use std::borrow::Cow;
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+/// Strips all ANSI control sequences from some text.
+pub fn strip_ansi_escapes(text: &str) -> Cow<str> {
+    lazy_static! {
+        // This regex was taken from the following page:
+        // https://superuser.com/questions/380772/removing-ansi-color-codes-from-text-stream
+        static ref RE: Regex = Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap();
+    }
+    RE.replace_all(text, "")
+}

--- a/crates/pjsh/src/main.rs
+++ b/crates/pjsh/src/main.rs
@@ -1,6 +1,10 @@
 mod action;
+mod command_shell;
+mod completion;
 mod exec;
+mod file_shell;
 mod init;
+mod interactive_shell;
 mod shell;
 
 #[cfg(test)]
@@ -9,15 +13,16 @@ mod tests;
 use std::{path::PathBuf, sync::Arc};
 
 use clap::{crate_version, Parser};
+use command_shell::SingleCommandShell;
 use exec::create_executor;
+use file_shell::FileBufferShell;
 use init::initialized_context;
+use interactive_shell::RustylineShell;
 use parking_lot::Mutex;
 use pjsh_core::Context;
 use pjsh_exec::{interpolate_word, Executor, FileDescriptors};
 use pjsh_parse::{parse, parse_interpolation, ParseError};
-use shell::{
-    command::SingleCommandShell, file::FileBufferShell, interactive::RustylineShell, Shell,
-};
+use shell::Shell;
 
 /// Init script to always source when starting a new shell.
 const INIT_ALWAYS_SCRIPT_NAME: &str = ".pjsh/init-always.pjsh";

--- a/crates/pjsh/src/shell.rs
+++ b/crates/pjsh/src/shell.rs
@@ -1,11 +1,7 @@
-pub(crate) mod command;
-pub(crate) mod file;
-pub(crate) mod interactive;
-
 #[cfg(test)]
 use mockall::automock;
 
-pub enum ShellInput {
+pub(crate) enum ShellInput {
     /// A line of input.
     Line(String),
     /// Interrupt the current process.
@@ -17,7 +13,7 @@ pub enum ShellInput {
 }
 
 #[cfg_attr(test, automock)]
-pub trait Shell {
+pub(crate) trait Shell {
     /// Prompts the user for a line of input using a `prompt` text that may contain ANSI control
     /// sequences.
     fn prompt_line(&mut self, prompt: &str) -> ShellInput;


### PR DESCRIPTION
Implement a small engine for completing file names in interactive
shells.

This change is not intended to be final, and should be replaced by a
more feature-complete engine for user-defined completions.

Closes #9.