### PR TITLE
[#39] Add conditions

### DIFF
--- a/crates/pjsh_ast/src/lib.rs
+++ b/crates/pjsh_ast/src/lib.rs
@@ -80,6 +80,7 @@ pub struct Pipeline {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PipelineSegment {
-    pub command: Command,
+pub enum PipelineSegment {
+    Command(Command),
+    Condition(Vec<Word>),
 }

--- a/crates/pjsh_core/src/condition.rs
+++ b/crates/pjsh_core/src/condition.rs
@@ -1,0 +1,27 @@
+use crate::command::Args;
+
+/// A condition is something that can be evaluated as a [`bool`] by the shell.
+pub trait Condition: ConditionClone + Send + Sync {
+    /// Evaluates the condition.
+    fn evaluate(&self, args: Args) -> bool;
+}
+
+/// Helper trait for making it easier to clone `Box<Condition>`.
+pub trait ConditionClone {
+    fn clone_box(&self) -> Box<dyn Condition>;
+}
+
+impl<T> ConditionClone for T
+where
+    T: 'static + Condition + Clone,
+{
+    fn clone_box(&self) -> Box<dyn Condition> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn Condition> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}

--- a/crates/pjsh_core/src/lib.rs
+++ b/crates/pjsh_core/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod command;
+mod condition;
 mod context;
 mod env;
 pub(crate) mod eval;
 mod fs;
 pub mod utils;
 
+pub use condition::Condition;
 pub use context::Context;
 pub use env::host::Host;
 pub use env::std_host::StdHost;

--- a/crates/pjsh_exec/src/condition/fs.rs
+++ b/crates/pjsh_exec/src/condition/fs.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+
+use pjsh_core::{command::Args, Condition};
+
+/// A condition that is met when a given path exists.
+#[derive(Clone)]
+pub struct Exists(pub PathBuf);
+impl Condition for Exists {
+    fn evaluate(&self, _: Args) -> bool {
+        self.0.exists()
+    }
+}
+
+/// A condition that is met when a given path points to a file.
+#[derive(Clone)]
+pub struct IsFile(pub PathBuf);
+impl Condition for IsFile {
+    fn evaluate(&self, _: Args) -> bool {
+        self.0.is_file()
+    }
+}
+
+/// A condition that is met when a given path points to a directory.
+#[derive(Clone)]
+pub struct IsDirectory(pub PathBuf);
+impl Condition for IsDirectory {
+    fn evaluate(&self, _: Args) -> bool {
+        self.0.is_dir()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn args() -> Args {
+        Args {
+            context: pjsh_core::Context::default(),
+            io: pjsh_core::command::Io {
+                stdin: Box::new(std::io::empty()),
+                stdout: Box::new(std::io::sink()),
+                stderr: Box::new(std::io::sink()),
+            },
+        }
+    }
+
+    #[test]
+    fn exists() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("file");
+        let _ = std::fs::File::create(file_path.clone());
+        assert!(Exists(file_path).evaluate(args()));
+        assert!(Exists(dir.path().to_path_buf()).evaluate(args()));
+        assert!(!Exists(PathBuf::from("/non/existing/file")).evaluate(args()));
+        assert!(!Exists(PathBuf::from("/non/existing/dir/")).evaluate(args()));
+    }
+
+    #[test]
+    fn is_file() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("file");
+        let _ = std::fs::File::create(file_path.clone());
+        assert!(IsFile(file_path).evaluate(args()));
+        assert!(!IsFile(dir.path().to_path_buf()).evaluate(args()));
+        assert!(!IsFile(PathBuf::from("/non/existing/file")).evaluate(args()));
+        assert!(!IsFile(PathBuf::from("/non/existing/dir/")).evaluate(args()));
+    }
+
+    #[test]
+    fn is_directory() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("file");
+        let _ = std::fs::File::create(file_path.clone());
+        assert!(!IsDirectory(file_path).evaluate(args()));
+        assert!(IsDirectory(dir.path().to_path_buf()).evaluate(args()));
+        assert!(!IsDirectory(PathBuf::from("/non/existing/file")).evaluate(args()));
+        assert!(!IsDirectory(PathBuf::from("/non/existing/dir/")).evaluate(args()));
+    }
+}

--- a/crates/pjsh_exec/src/condition/logic.rs
+++ b/crates/pjsh_exec/src/condition/logic.rs
@@ -1,0 +1,40 @@
+use pjsh_core::{command::Args, Condition};
+
+/// A condition that is met when a wrapped condition is not met.
+#[derive(Clone)]
+pub struct Invert(pub Box<dyn Condition>);
+impl Condition for Invert {
+    fn evaluate(&self, args: Args) -> bool {
+        !self.0.evaluate(args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct True;
+    impl Condition for True {
+        fn evaluate(&self, _: Args) -> bool {
+            true
+        }
+    }
+
+    fn args() -> Args {
+        Args {
+            context: pjsh_core::Context::default(),
+            io: pjsh_core::command::Io {
+                stdin: Box::new(std::io::empty()),
+                stdout: Box::new(std::io::sink()),
+                stderr: Box::new(std::io::sink()),
+            },
+        }
+    }
+
+    #[test]
+    fn equal() {
+        assert!(!Invert(Box::new(True {})).evaluate(args()));
+        assert!(Invert(Box::new(Invert(Box::new(True {})))).evaluate(args()));
+    }
+}

--- a/crates/pjsh_exec/src/condition/mod.rs
+++ b/crates/pjsh_exec/src/condition/mod.rs
@@ -1,0 +1,53 @@
+mod fs;
+mod logic;
+mod string;
+
+use pjsh_core::{utils::resolve_path, Condition, Context};
+
+use crate::error::ExecError;
+
+/// Parses a [`Condition`].
+pub(crate) fn parse_condition(
+    input: &[&str],
+    ctx: &Context,
+) -> Result<Box<dyn Condition>, ExecError> {
+    // The "!" symbol can be used to invert a condition.
+    if matches!(input.first(), Some(&"!")) {
+        return Ok(Box::new(logic::Invert(parse_condition(&input[1..], ctx)?)));
+    }
+
+    match input {
+        // String-related conditions.
+        [a, "!=", b] => Ok(Box::new(string::NotEqual(a.to_string(), b.to_string()))),
+        [a, "==", b] => Ok(Box::new(string::Equal(a.to_string(), b.to_string()))),
+        [a, "=", b] => Ok(Box::new(string::Equal(a.to_string(), b.to_string()))),
+        ["-z", string] => Ok(Box::new(string::Empty(string.to_string()))),
+        ["-n", string] => Ok(Box::new(string::NotEmpty(string.to_string()))),
+        [string] => Ok(Box::new(string::NotEmpty(string.to_string()))),
+
+        // File-related conditions.
+        ["-e", path] => Ok(Box::new(fs::Exists(resolve_path(ctx, path)))),
+        ["is-path", path] => Ok(Box::new(fs::Exists(resolve_path(ctx, path)))),
+        ["-f", path] => Ok(Box::new(fs::IsFile(resolve_path(ctx, path)))),
+        ["is-file", path] => Ok(Box::new(fs::IsFile(resolve_path(ctx, path)))),
+        ["-d", path] => Ok(Box::new(fs::IsDirectory(resolve_path(ctx, path)))),
+        ["is-dir", path] => Ok(Box::new(fs::IsDirectory(resolve_path(ctx, path)))),
+
+        // Undefined conditions are considered invalid.
+        _ => {
+            let mut text = String::new();
+            let mut words = input.iter();
+
+            if let Some(word) = words.next() {
+                text.push_str(word.as_ref());
+            }
+
+            for word in words {
+                text.push(' ');
+                text.push_str(word.as_ref());
+            }
+
+            Err(ExecError::Message(format!("invalid condition: {text}")))
+        }
+    }
+}

--- a/crates/pjsh_exec/src/condition/string.rs
+++ b/crates/pjsh_exec/src/condition/string.rs
@@ -1,0 +1,77 @@
+use pjsh_core::{command::Args, Condition};
+
+/// A condition that is met when two strings are equal to each other.
+#[derive(Clone)]
+pub struct Equal(pub String, pub String);
+impl Condition for Equal {
+    fn evaluate(&self, _: Args) -> bool {
+        self.0 == self.1
+    }
+}
+
+/// A condition that is met when two strings are not equal to each other.
+#[derive(Clone)]
+pub struct NotEqual(pub String, pub String);
+impl Condition for NotEqual {
+    fn evaluate(&self, _: Args) -> bool {
+        self.0 != self.1
+    }
+}
+
+/// A condition that is met when a string is empty.
+#[derive(Clone)]
+pub struct Empty(pub String);
+impl Condition for Empty {
+    fn evaluate(&self, _: Args) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A condition that is met when a string is not empty.
+#[derive(Clone)]
+pub struct NotEmpty(pub String);
+impl Condition for NotEmpty {
+    fn evaluate(&self, _: Args) -> bool {
+        !self.0.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args() -> Args {
+        Args {
+            context: pjsh_core::Context::default(),
+            io: pjsh_core::command::Io {
+                stdin: Box::new(std::io::empty()),
+                stdout: Box::new(std::io::sink()),
+                stderr: Box::new(std::io::sink()),
+            },
+        }
+    }
+
+    #[test]
+    fn equal() {
+        assert!(Equal("a".into(), "a".into()).evaluate(args()));
+        assert!(!Equal("a".into(), "b".into()).evaluate(args()));
+    }
+
+    #[test]
+    fn not_equal() {
+        assert!(NotEqual("a".into(), "b".into()).evaluate(args()));
+        assert!(!NotEqual("a".into(), "a".into()).evaluate(args()));
+    }
+
+    #[test]
+    fn empty() {
+        assert!(Empty("".into()).evaluate(args()));
+        assert!(!Empty("not-empty".into()).evaluate(args()));
+    }
+
+    #[test]
+    fn not_empty() {
+        assert!(NotEmpty("not-empty".into()).evaluate(args()));
+        assert!(!NotEmpty("".into()).evaluate(args()));
+    }
+}

--- a/crates/pjsh_exec/src/lib.rs
+++ b/crates/pjsh_exec/src/lib.rs
@@ -1,3 +1,4 @@
+mod condition;
 mod error;
 mod executor;
 mod exit;

--- a/crates/pjsh_exec/src/tests/and_or.rs
+++ b/crates/pjsh_exec/src/tests/and_or.rs
@@ -8,13 +8,11 @@ use crate::{tests::utils::test_executor, FileDescriptors};
 fn pipeline(exit_status: i32) -> Pipeline {
     Pipeline {
         is_async: false,
-        segments: vec![PipelineSegment {
-            command: Command {
-                program: Word::Literal("exit".into()),
-                arguments: vec![Word::Literal(format!("{}", exit_status))],
-                redirects: Vec::new(),
-            },
-        }],
+        segments: vec![PipelineSegment::Command(Command {
+            program: Word::Literal("exit".into()),
+            arguments: vec![Word::Literal(format!("{}", exit_status))],
+            redirects: Vec::new(),
+        })],
     }
 }
 

--- a/crates/pjsh_exec/src/tests/condition.rs
+++ b/crates/pjsh_exec/src/tests/condition.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use pjsh_ast::{AndOr, Pipeline, PipelineSegment, Word};
+use pjsh_core::Context;
+
+use crate::{tests::utils::test_executor, FileDescriptors};
+
+fn pipeline(condition: &[&str]) -> Pipeline {
+    let input = condition
+        .iter()
+        .map(|word| Word::Literal(word.to_string()))
+        .collect();
+
+    Pipeline {
+        is_async: false,
+        segments: vec![PipelineSegment::Condition(input)],
+    }
+}
+
+#[test]
+fn true_condition() {
+    let fds = FileDescriptors::new();
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = test_executor();
+    let and_or = AndOr {
+        operators: Vec::new(),
+        pipelines: vec![pipeline(&["true", "==", "true"])],
+    };
+    executor.execute_and_or(and_or, Arc::clone(&ctx), &fds);
+    assert_eq!(ctx.lock().last_exit, 0);
+}
+
+#[test]
+fn false_condition() {
+    let fds = FileDescriptors::new();
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = test_executor();
+    let and_or = AndOr {
+        operators: Vec::new(),
+        pipelines: vec![pipeline(&["true", "==", "false"])],
+    };
+    executor.execute_and_or(and_or, Arc::clone(&ctx), &fds);
+    assert_eq!(ctx.lock().last_exit, 1);
+}
+
+#[test]
+fn inverted_condition() {
+    let fds = FileDescriptors::new();
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = test_executor();
+    let and_or = AndOr {
+        operators: Vec::new(),
+        pipelines: vec![pipeline(&["!", "true", "==", "false"])],
+    };
+    executor.execute_and_or(and_or, Arc::clone(&ctx), &fds);
+    assert_eq!(ctx.lock().last_exit, 0); // !false == true
+}
+
+#[test]
+fn invalid_condition() {
+    let fds = FileDescriptors::new();
+    let ctx = Arc::new(parking_lot::Mutex::new(Context::default()));
+    let executor = test_executor();
+    let and_or = AndOr {
+        operators: Vec::new(),
+        pipelines: vec![pipeline(&["invalid", "condition"])],
+    };
+    executor.execute_and_or(and_or, Arc::clone(&ctx), &fds);
+    assert_ne!(ctx.lock().last_exit, 0);
+}

--- a/crates/pjsh_exec/src/tests/mod.rs
+++ b/crates/pjsh_exec/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod and_or;
+mod condition;
 mod program;
 mod statement;
 mod utils;

--- a/crates/pjsh_exec/src/tests/program.rs
+++ b/crates/pjsh_exec/src/tests/program.rs
@@ -17,13 +17,11 @@ fn execute_program() {
             operators: Vec::new(),
             pipelines: vec![Pipeline {
                 is_async: false,
-                segments: vec![PipelineSegment {
-                    command: Command {
-                        program: Word::Literal("echo".into()),
-                        arguments: vec![Word::Literal("Hello, world!".into())],
-                        redirects: Vec::new(),
-                    },
-                }],
+                segments: vec![PipelineSegment::Command(Command {
+                    program: Word::Literal("echo".into()),
+                    arguments: vec![Word::Literal("Hello, world!".into())],
+                    redirects: Vec::new(),
+                })],
             }],
         })],
     };
@@ -44,17 +42,15 @@ fn execute_program_stderr() {
             operators: Vec::new(),
             pipelines: vec![Pipeline {
                 is_async: false,
-                segments: vec![PipelineSegment {
-                    command: Command {
-                        program: Word::Literal("echo".into()),
-                        arguments: vec![Word::Literal("Hello, world!".into())],
-                        redirects: vec![Redirect {
-                            source: FileDescriptor::Number(1), // Stdout
-                            target: FileDescriptor::Number(2), // Stderr
-                            operator: pjsh_ast::RedirectOperator::Write,
-                        }],
-                    },
-                }],
+                segments: vec![PipelineSegment::Command(Command {
+                    program: Word::Literal("echo".into()),
+                    arguments: vec![Word::Literal("Hello, world!".into())],
+                    redirects: vec![Redirect {
+                        source: FileDescriptor::Number(1), // Stdout
+                        target: FileDescriptor::Number(2), // Stderr
+                        operator: pjsh_ast::RedirectOperator::Write,
+                    }],
+                })],
             }],
         })],
     };

--- a/crates/pjsh_exec/src/tests/statement.rs
+++ b/crates/pjsh_exec/src/tests/statement.rs
@@ -10,13 +10,11 @@ use crate::{tests::utils::test_executor, FileDescriptors};
 fn pipeline(exit_status: i32) -> Pipeline {
     Pipeline {
         is_async: false,
-        segments: vec![PipelineSegment {
-            command: Command {
-                program: Word::Literal("exit".into()),
-                arguments: vec![Word::Literal(format!("{}", exit_status))],
-                redirects: Vec::new(),
-            },
-        }],
+        segments: vec![PipelineSegment::Command(Command {
+            program: Word::Literal("exit".into()),
+            arguments: vec![Word::Literal(format!("{}", exit_status))],
+            redirects: Vec::new(),
+        })],
     }
 }
 

--- a/crates/pjsh_parse/src/lex/tests.rs
+++ b/crates/pjsh_parse/src/lex/tests.rs
@@ -47,6 +47,22 @@ fn lex_comment() {
 }
 
 #[test]
+fn lex_surrounding_chars() {
+    assert_eq!(tokens("("), vec![Token::new(OpenParen, Span::new(0, 1))]);
+    assert_eq!(tokens(")"), vec![Token::new(CloseParen, Span::new(0, 1))]);
+    assert_eq!(tokens("{"), vec![Token::new(OpenBrace, Span::new(0, 1))]);
+    assert_eq!(tokens("}"), vec![Token::new(CloseBrace, Span::new(0, 1))]);
+    assert_eq!(
+        tokens("[["),
+        vec![Token::new(DoubleOpenBracket, Span::new(0, 2))]
+    );
+    assert_eq!(
+        tokens("]]"),
+        vec![Token::new(DoubleCloseBracket, Span::new(0, 2))]
+    );
+}
+
+#[test]
 fn lex_literal() {
     assert_eq!(
         tokens("literal"),

--- a/crates/pjsh_parse/src/parse/tests.rs
+++ b/crates/pjsh_parse/src/parse/tests.rs
@@ -46,6 +46,32 @@ fn parse_multiline_word() {
 }
 
 #[test]
+fn parse_condition() {
+    let span = Span::new(0, 0); // Does not matter during this test.
+    let mut parser = Parser::new(vec![
+        Token::new(DoubleOpenBracket, span),
+        Token::new(Literal("a".into()), span),
+        Token::new(Literal("=".into()), span),
+        Token::new(Literal("b".into()), span),
+        Token::new(DoubleCloseBracket, span),
+    ]);
+    assert_eq!(
+        parser.parse_and_or(),
+        Ok(AndOr {
+            operators: Vec::new(),
+            pipelines: vec![Pipeline {
+                is_async: false,
+                segments: vec![PipelineSegment::Condition(vec![
+                    Word::Literal("a".into()),
+                    Word::Literal("=".into()),
+                    Word::Literal("b".into()),
+                ])]
+            },]
+        })
+    );
+}
+
+#[test]
 fn parse_and_or_andif() {
     let span = Span::new(0, 0); // Does not matter during this test.
     let mut parser = Parser::new(vec![
@@ -60,23 +86,19 @@ fn parse_and_or_andif() {
             pipelines: vec![
                 Pipeline {
                     is_async: false,
-                    segments: vec![PipelineSegment {
-                        command: Command {
-                            program: Word::Literal("first".into()),
-                            arguments: Vec::new(),
-                            redirects: Vec::new(),
-                        }
-                    },]
+                    segments: vec![PipelineSegment::Command(Command {
+                        program: Word::Literal("first".into()),
+                        arguments: Vec::new(),
+                        redirects: Vec::new(),
+                    }),]
                 },
                 Pipeline {
                     is_async: false,
-                    segments: vec![PipelineSegment {
-                        command: Command {
-                            program: Word::Literal("second".into()),
-                            arguments: Vec::new(),
-                            redirects: Vec::new(),
-                        }
-                    },]
+                    segments: vec![PipelineSegment::Command(Command {
+                        program: Word::Literal("second".into()),
+                        arguments: Vec::new(),
+                        redirects: Vec::new(),
+                    })]
                 }
             ]
         })
@@ -98,23 +120,19 @@ fn parse_and_or_orif() {
             pipelines: vec![
                 Pipeline {
                     is_async: false,
-                    segments: vec![PipelineSegment {
-                        command: Command {
-                            program: Word::Literal("first".into()),
-                            arguments: Vec::new(),
-                            redirects: Vec::new(),
-                        }
-                    },]
+                    segments: vec![PipelineSegment::Command(Command {
+                        program: Word::Literal("first".into()),
+                        arguments: Vec::new(),
+                        redirects: Vec::new(),
+                    }),]
                 },
                 Pipeline {
                     is_async: false,
-                    segments: vec![PipelineSegment {
-                        command: Command {
-                            program: Word::Literal("second".into()),
-                            arguments: Vec::new(),
-                            redirects: Vec::new(),
-                        }
-                    },]
+                    segments: vec![PipelineSegment::Command(Command {
+                        program: Word::Literal("second".into()),
+                        arguments: Vec::new(),
+                        redirects: Vec::new(),
+                    }),]
                 }
             ]
         })
@@ -134,20 +152,16 @@ fn parse_legacy_pipeline() {
         Ok(Pipeline {
             is_async: false,
             segments: vec![
-                PipelineSegment {
-                    command: Command {
-                        program: Word::Literal("first".into()),
-                        arguments: vec![Word::Literal("second".into())],
-                        redirects: Vec::new(),
-                    }
-                },
-                PipelineSegment {
-                    command: Command {
-                        program: Word::Literal("third".into()),
-                        arguments: Vec::new(),
-                        redirects: Vec::new(),
-                    }
-                }
+                PipelineSegment::Command(Command {
+                    program: Word::Literal("first".into()),
+                    arguments: vec![Word::Literal("second".into())],
+                    redirects: Vec::new(),
+                }),
+                PipelineSegment::Command(Command {
+                    program: Word::Literal("third".into()),
+                    arguments: Vec::new(),
+                    redirects: Vec::new(),
+                }),
             ]
         })
     );
@@ -163,13 +177,11 @@ fn parse_legacy_pipeline_async() {
         parser.parse_pipeline(),
         Ok(Pipeline {
             is_async: true,
-            segments: vec![PipelineSegment {
-                command: Command {
-                    program: Word::Literal("command".into()),
-                    arguments: Vec::new(),
-                    redirects: Vec::new(),
-                }
-            },]
+            segments: vec![PipelineSegment::Command(Command {
+                program: Word::Literal("command".into()),
+                arguments: Vec::new(),
+                redirects: Vec::new(),
+            }),]
         })
     );
 }
@@ -191,20 +203,16 @@ fn parse_smart_pipeline() {
         Ok(Pipeline {
             is_async: false,
             segments: vec![
-                PipelineSegment {
-                    command: Command {
-                        program: Word::Literal("cmd1".into()),
-                        arguments: Vec::new(),
-                        redirects: Vec::new(),
-                    }
-                },
-                PipelineSegment {
-                    command: Command {
-                        program: Word::Literal("cmd2".into()),
-                        arguments: Vec::new(),
-                        redirects: Vec::new(),
-                    }
-                }
+                PipelineSegment::Command(Command {
+                    program: Word::Literal("cmd1".into()),
+                    arguments: Vec::new(),
+                    redirects: Vec::new(),
+                }),
+                PipelineSegment::Command(Command {
+                    program: Word::Literal("cmd2".into()),
+                    arguments: Vec::new(),
+                    redirects: Vec::new(),
+                }),
             ]
         })
     );
@@ -227,13 +235,11 @@ fn parse_smart_pipeline_whitespace() {
         parser.parse_pipeline(),
         Ok(Pipeline {
             is_async: false,
-            segments: vec![PipelineSegment {
-                command: Command {
-                    program: Word::Literal("cmd".into()),
-                    arguments: vec![Word::Literal("arg1".into()), Word::Literal("arg2".into())],
-                    redirects: Vec::new(),
-                }
-            },]
+            segments: vec![PipelineSegment::Command(Command {
+                program: Word::Literal("cmd".into()),
+                arguments: vec![Word::Literal("arg1".into()), Word::Literal("arg2".into())],
+                redirects: Vec::new(),
+            }),]
         })
     );
 }
@@ -278,13 +284,11 @@ fn parse_smart_async_pipeline() {
         parser.parse_pipeline(),
         Ok(Pipeline {
             is_async: true,
-            segments: vec![PipelineSegment {
-                command: Command {
-                    program: Word::Literal("command".into()),
-                    arguments: Vec::new(),
-                    redirects: Vec::new(),
-                }
-            },]
+            segments: vec![PipelineSegment::Command(Command {
+                program: Word::Literal("command".into()),
+                arguments: Vec::new(),
+                redirects: Vec::new(),
+            }),]
         })
     );
 }
@@ -329,13 +333,11 @@ fn parse_function_statement() {
                     operators: Vec::new(),
                     pipelines: vec![Pipeline {
                         is_async: false,
-                        segments: vec![PipelineSegment {
-                            command: Command {
-                                program: Word::Literal("echo".into()),
-                                arguments: vec![Word::Literal("test".into())],
-                                redirects: Vec::new(),
-                            }
-                        }]
+                        segments: vec![PipelineSegment::Command(Command {
+                            program: Word::Literal("echo".into()),
+                            arguments: vec![Word::Literal("test".into())],
+                            redirects: Vec::new(),
+                        })]
                     }]
                 })]
             }
@@ -361,13 +363,11 @@ fn parse_if_statement() {
                 operators: Vec::new(),
                 pipelines: vec![Pipeline {
                     is_async: false,
-                    segments: vec![PipelineSegment {
-                        command: Command {
-                            program: Word::Literal("true".into()),
-                            arguments: Vec::new(),
-                            redirects: Vec::new(),
-                        }
-                    }]
+                    segments: vec![PipelineSegment::Command(Command {
+                        program: Word::Literal("true".into()),
+                        arguments: Vec::new(),
+                        redirects: Vec::new(),
+                    })]
                 }]
             }],
             branches: vec![Program {
@@ -375,13 +375,11 @@ fn parse_if_statement() {
                     operators: Vec::new(),
                     pipelines: vec![Pipeline {
                         is_async: false,
-                        segments: vec![PipelineSegment {
-                            command: Command {
-                                program: Word::Literal("echo".into()),
-                                arguments: vec![Word::Literal("test".into())],
-                                redirects: Vec::new(),
-                            }
-                        }]
+                        segments: vec![PipelineSegment::Command(Command {
+                            program: Word::Literal("echo".into()),
+                            arguments: vec![Word::Literal("test".into())],
+                            redirects: Vec::new(),
+                        })]
                     }]
                 })]
             }]
@@ -420,26 +418,22 @@ fn parse_if_statement_with_multiple_branches() {
                     operators: Vec::new(),
                     pipelines: vec![Pipeline {
                         is_async: false,
-                        segments: vec![PipelineSegment {
-                            command: Command {
-                                program: Word::Literal("false".into()),
-                                arguments: Vec::new(),
-                                redirects: Vec::new(),
-                            }
-                        }]
+                        segments: vec![PipelineSegment::Command(Command {
+                            program: Word::Literal("false".into()),
+                            arguments: Vec::new(),
+                            redirects: Vec::new(),
+                        })]
                     }]
                 },
                 AndOr {
                     operators: Vec::new(),
                     pipelines: vec![Pipeline {
                         is_async: false,
-                        segments: vec![PipelineSegment {
-                            command: Command {
-                                program: Word::Literal("false".into()),
-                                arguments: Vec::new(),
-                                redirects: Vec::new(),
-                            }
-                        }]
+                        segments: vec![PipelineSegment::Command(Command {
+                            program: Word::Literal("false".into()),
+                            arguments: Vec::new(),
+                            redirects: Vec::new(),
+                        })]
                     }]
                 }
             ],
@@ -449,13 +443,11 @@ fn parse_if_statement_with_multiple_branches() {
                         operators: Vec::new(),
                         pipelines: vec![Pipeline {
                             is_async: false,
-                            segments: vec![PipelineSegment {
-                                command: Command {
-                                    program: Word::Literal("echo".into()),
-                                    arguments: vec![Word::Literal("first".into())],
-                                    redirects: Vec::new(),
-                                }
-                            }]
+                            segments: vec![PipelineSegment::Command(Command {
+                                program: Word::Literal("echo".into()),
+                                arguments: vec![Word::Literal("first".into())],
+                                redirects: Vec::new(),
+                            })]
                         }]
                     })]
                 },
@@ -464,13 +456,11 @@ fn parse_if_statement_with_multiple_branches() {
                         operators: Vec::new(),
                         pipelines: vec![Pipeline {
                             is_async: false,
-                            segments: vec![PipelineSegment {
-                                command: Command {
-                                    program: Word::Literal("echo".into()),
-                                    arguments: vec![Word::Literal("second".into())],
-                                    redirects: Vec::new(),
-                                }
-                            }]
+                            segments: vec![PipelineSegment::Command(Command {
+                                program: Word::Literal("echo".into()),
+                                arguments: vec![Word::Literal("second".into())],
+                                redirects: Vec::new(),
+                            })]
                         }]
                     })]
                 },
@@ -479,13 +469,11 @@ fn parse_if_statement_with_multiple_branches() {
                         operators: Vec::new(),
                         pipelines: vec![Pipeline {
                             is_async: false,
-                            segments: vec![PipelineSegment {
-                                command: Command {
-                                    program: Word::Literal("echo".into()),
-                                    arguments: vec![Word::Literal("third".into())],
-                                    redirects: Vec::new(),
-                                }
-                            }]
+                            segments: vec![PipelineSegment::Command(Command {
+                                program: Word::Literal("echo".into()),
+                                arguments: vec![Word::Literal("third".into())],
+                                redirects: Vec::new(),
+                            })]
                         }]
                     })]
                 }
@@ -510,13 +498,11 @@ fn parse_statement_before_unexpected() {
             operators: Vec::new(),
             pipelines: vec![Pipeline {
                 is_async: false,
-                segments: vec![PipelineSegment {
-                    command: Command {
-                        program: Word::Literal("echo".into()),
-                        arguments: vec![Word::Literal("test".into())],
-                        redirects: Vec::new(),
-                    }
-                }]
+                segments: vec![PipelineSegment::Command(Command {
+                    program: Word::Literal("echo".into()),
+                    arguments: vec![Word::Literal("test".into())],
+                    redirects: Vec::new(),
+                })]
             }]
         }))
     );
@@ -592,26 +578,22 @@ fn parse_program() {
                     operators: vec![],
                     pipelines: vec![Pipeline {
                         is_async: false,
-                        segments: vec![PipelineSegment {
-                            command: Command {
-                                program: Word::Literal("cmd1".into()),
-                                arguments: vec![Word::Literal("arg1".into())],
-                                redirects: Vec::new(),
-                            }
-                        },]
+                        segments: vec![PipelineSegment::Command(Command {
+                            program: Word::Literal("cmd1".into()),
+                            arguments: vec![Word::Literal("arg1".into())],
+                            redirects: Vec::new(),
+                        }),]
                     }]
                 }),
                 Statement::AndOr(AndOr {
                     operators: vec![],
                     pipelines: vec![Pipeline {
                         is_async: false,
-                        segments: vec![PipelineSegment {
-                            command: Command {
-                                program: Word::Literal("cmd2".into()),
-                                arguments: vec![Word::Literal("arg2".into())],
-                                redirects: Vec::new(),
-                            }
-                        },]
+                        segments: vec![PipelineSegment::Command(Command {
+                            program: Word::Literal("cmd2".into()),
+                            arguments: vec![Word::Literal("arg2".into())],
+                            redirects: Vec::new(),
+                        }),]
                     }]
                 })
             ]
@@ -630,26 +612,22 @@ fn parse_subshell() {
                         operators: vec![],
                         pipelines: vec![Pipeline {
                             is_async: false,
-                            segments: vec![PipelineSegment {
-                                command: Command {
-                                    program: Word::Literal("cmd1".into()),
-                                    arguments: vec![Word::Literal("arg1".into())],
-                                    redirects: Vec::new(),
-                                }
-                            },]
+                            segments: vec![PipelineSegment::Command(Command {
+                                program: Word::Literal("cmd1".into()),
+                                arguments: vec![Word::Literal("arg1".into())],
+                                redirects: Vec::new(),
+                            }),]
                         }]
                     }),
                     Statement::AndOr(AndOr {
                         operators: vec![],
                         pipelines: vec![Pipeline {
                             is_async: false,
-                            segments: vec![PipelineSegment {
-                                command: Command {
-                                    program: Word::Literal("cmd2".into()),
-                                    arguments: vec![Word::Literal("arg2".into())],
-                                    redirects: Vec::new(),
-                                }
-                            },]
+                            segments: vec![PipelineSegment::Command(Command {
+                                program: Word::Literal("cmd2".into()),
+                                arguments: vec![Word::Literal("arg2".into())],
+                                redirects: Vec::new(),
+                            }),]
                         }]
                     })
                 ]
@@ -667,30 +645,26 @@ fn parse_subshell_interpolation() {
                 operators: Vec::new(),
                 pipelines: vec![Pipeline {
                     is_async: false,
-                    segments: vec![PipelineSegment {
-                        command: Command {
-                            program: Word::Literal("echo".into()),
-                            arguments: vec![Word::Interpolation(vec![
-                                InterpolationUnit::Literal("today: ".into()),
-                                InterpolationUnit::Subshell(Program {
-                                    statements: vec![Statement::AndOr(AndOr {
-                                        operators: vec![],
-                                        pipelines: vec![Pipeline {
-                                            is_async: false,
-                                            segments: vec![PipelineSegment {
-                                                command: Command {
-                                                    program: Word::Literal("date".into()),
-                                                    arguments: Vec::new(),
-                                                    redirects: Vec::new(),
-                                                }
-                                            },]
-                                        }]
-                                    }),]
-                                })
-                            ])],
-                            redirects: Vec::new(),
-                        }
-                    }]
+                    segments: vec![PipelineSegment::Command(Command {
+                        program: Word::Literal("echo".into()),
+                        arguments: vec![Word::Interpolation(vec![
+                            InterpolationUnit::Literal("today: ".into()),
+                            InterpolationUnit::Subshell(Program {
+                                statements: vec![Statement::AndOr(AndOr {
+                                    operators: vec![],
+                                    pipelines: vec![Pipeline {
+                                        is_async: false,
+                                        segments: vec![PipelineSegment::Command(Command {
+                                            program: Word::Literal("date".into()),
+                                            arguments: Vec::new(),
+                                            redirects: Vec::new(),
+                                        }),]
+                                    }]
+                                }),]
+                            })
+                        ])],
+                        redirects: Vec::new(),
+                    })]
                 }]
             })]
         })

--- a/crates/pjsh_parse/src/tokens.rs
+++ b/crates/pjsh_parse/src/tokens.rs
@@ -23,10 +23,10 @@ pub enum TokenContents {
     OpenBrace,
     /// "}"
     CloseBrace,
-    /// "["
-    OpenBracket,
-    /// "]"
-    CloseBracket,
+    /// "[["
+    DoubleOpenBracket,
+    /// "]}"
+    DoubleCloseBracket,
 
     /// "&&"
     AndIf,

--- a/doc/src/conditionals.md
+++ b/doc/src/conditionals.md
@@ -48,6 +48,14 @@ rm output.tmp || true
 The shell supports more complex conditionals using _if-statements_. Such statements contain a body that is executed if a condition is met.
 
 ```pjsh
+if <condition> {
+  # Conditional code goes here.
+}
+```
+
+An example:
+
+```pjsh
 if true {
   echo "This should be printed"
 }
@@ -76,3 +84,30 @@ if false {
 ```
 
 If-statements always exit with code `0` unless a command fails within the executed branch.
+
+### Conditions
+
+Compact conditions can be declared using the `[[ ... ]]` syntax.
+
+| Expression           | Description                                    |
+| :------------------- | :--------------------------------------------- |
+| `[[ -e path ]]`      | True if `path` exists.                         |
+| `[[ is-path path ]]` | True if `path` exists.                         |
+| `[[ -f path ]]`      | True if `path` is a file.                      |
+| `[[ is-file path ]]` | True if `path` is a file.                      |
+| `[[ -d path ]]`      | True if `path` is a directory.                 |
+| `[[ is-dir path ]]`  | True if `path` is a directory.                 |
+| `[[ a != b ]]`       | True if the strings `a` and `b` are different. |
+| `[[ a == b ]]`       | True if the strings `a` and `b` are equal.     |
+| `[[ a = b ]]`        | True if the strings `a` and `b` are equal.     |
+| `[[ -z string ]]`    | True if the string `string` is empty.          |
+| `[[ -n string ]]`    | True if the string `string` is not empty.      |
+| `[[ string ]]`       | True if the string `string` is not empty.      |
+
+Furthermore, a condition can be inverted using the `!` symbol:
+
+```pjsh
+if [[ ! -e path ]] {
+  echo "The path does not exist!"
+}
+```


### PR DESCRIPTION
Add basic condition statements.

 | Expression        | Description                                    |
 | :---------------- | :--------------------------------------------- |
 | `[[ -e path ]]`   | True if `path` exists.                         |
 | `[[ -f path ]]`   | True if `path` is a file.                      |
 | `[[ -d path ]]`   | True if `path` is a directory.                 |
 | `[[ a != b ]]`    | True if the strings `a` and `b` are different. |
 | `[[ a == b ]]`    | True if the strings `a` and `b` are equal.     |
 | `[[ a = b ]]`     | True if the strings `a` and `b` are equal.     |
 | `[[ -z string ]]` | True if the string `string` is empty.          |
 | `[[ -n string ]]` | True if the string `string` is not empty.      |
 | `[[ string ]]`    | True if the string `string` is not empty.      |

Closes #39.