### PR TITLE
Fix default shell output issues

### DIFF
--- a/crates/pjsh/src/init/context.rs
+++ b/crates/pjsh/src/init/context.rs
@@ -61,7 +61,7 @@ fn inject_external_envs(ctx: &Context) {
 
 /// Injects static default environment variables into a context.
 fn inject_static_defaults(ctx: &Context) {
-    ctx.scope.set_env(String::from("PS1"), String::from("$ "));
+    ctx.scope.set_env(String::from("PS1"), String::from("\\$ "));
     ctx.scope.set_env(String::from("PS2"), String::from("> "));
     ctx.scope.set_env(String::from("PS4"), String::from("+ "));
 }

--- a/crates/pjsh/src/main.rs
+++ b/crates/pjsh/src/main.rs
@@ -92,7 +92,7 @@ fn get_prompts(interactive: bool, context: &Context, executor: &Executor) -> (St
         &context
             .scope
             .get_env("PS1")
-            .unwrap_or_else(|| String::from("$ ")),
+            .unwrap_or_else(|| String::from("\\$ ")),
         context,
         executor,
     );
@@ -123,7 +123,10 @@ pub(crate) fn run_shell(mut shell: Box<dyn Shell>, context: Arc<Mutex<Context>>)
                 interrupt(&mut context.lock());
                 continue;
             }
-            shell::ShellInput::Logout => break 'main,
+            shell::ShellInput::Logout => {
+                context.lock().host.lock().eprintln("pjsh: logout");
+                break 'main;
+            }
             shell::ShellInput::None => break,
         };
 
@@ -149,7 +152,10 @@ pub(crate) fn run_shell(mut shell: Box<dyn Shell>, context: Arc<Mutex<Context>>)
                             interrupt(&mut context.lock());
                             continue 'main;
                         }
-                        shell::ShellInput::Logout => break 'main,
+                        shell::ShellInput::Logout => {
+                            context.lock().host.lock().eprintln("pjsh: logout");
+                            break 'main;
+                        }
                         shell::ShellInput::None => break,
                     };
                 }

--- a/crates/pjsh/src/tests.rs
+++ b/crates/pjsh/src/tests.rs
@@ -33,6 +33,10 @@ fn shell_interrupt() {
         .expect_eprintln()
         .with(eq("pjsh: interrupt"))
         .return_const(());
+    mock_host
+        .expect_eprintln()
+        .with(eq("pjsh: logout"))
+        .return_const(());
 
     mock_host
         .expect_kill_all_processes()


### PR DESCRIPTION
 - Make the default PS1 value work with interpolation.
 - Print a message to stderr on logout.