### PR TITLE
Add lazy environment evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,6 @@ dependencies = [
  "regex",
  "rustyline",
  "rustyline-derive",
- "sysinfo",
 ]
 
 [[package]]
@@ -651,6 +650,7 @@ dependencies = [
  "pjsh_ast",
  "pjsh_core",
  "pjsh_parse",
+ "sysinfo",
  "tempfile",
 ]
 

--- a/crates/pjsh/Cargo.toml
+++ b/crates/pjsh/Cargo.toml
@@ -13,7 +13,6 @@ parking_lot = {version = "0.12.0", features = ["deadlock_detection"] }
 regex = "1"
 rustyline = "9.1"
 rustyline-derive = "0.6"
-sysinfo = "0.24.2"
 
 pjsh_ast = { path = "../pjsh_ast" }
 pjsh_builtins = { path = "../pjsh_builtins" }

--- a/crates/pjsh/src/init/context.rs
+++ b/crates/pjsh/src/init/context.rs
@@ -1,7 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use sysinfo::{get_current_pid, ProcessExt, ProcessRefreshKind, RefreshKind, System, SystemExt};
-
 use pjsh_core::{utils::path_to_string, Context, Host, Scope, StdHost};
 
 /// Constructs a new initialized execution context containing some common environment variables such
@@ -41,35 +39,11 @@ fn environment_scope<H: Host>(host: H) -> Scope {
 
 /// Returns a scope containing shell-specific default variables.
 fn pjsh_scope(interactive: bool) -> Scope {
-    let mut vars = HashMap::from([
+    let vars = HashMap::from([
         ("PS1".to_owned(), "\\$ ".to_owned()),
         ("PS2".to_owned(), "> ".to_owned()),
         ("PS4".to_owned(), "+ ".to_owned()),
     ]);
-
-    if let Ok(exe) = std::env::current_exe().map(|path| path_to_string(&path)) {
-        vars.insert("SHELL".to_owned(), exe);
-    }
-
-    if let Ok(pwd) = std::env::current_dir().map(|path| path_to_string(&path)) {
-        vars.insert("PWD".to_owned(), pwd);
-    }
-
-    if let Some(home_dir) = dirs::home_dir().map(|path| path_to_string(&path)) {
-        vars.insert("HOME".to_owned(), home_dir);
-    }
-
-    // Parent process id.
-    if let Ok(pid) = get_current_pid() {
-        let system = System::new_with_specifics(
-            RefreshKind::new().with_processes(ProcessRefreshKind::everything()),
-        );
-        if let Some(process) = system.process(pid) {
-            if let Some(parent_id) = process.parent() {
-                vars.insert("PPID".to_owned(), parent_id.to_string());
-            }
-        }
-    }
 
     Scope::new(
         "pjsh".to_owned(),

--- a/crates/pjsh_exec/Cargo.toml
+++ b/crates/pjsh_exec/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 dirs = "4.0"
 os_pipe = "1.0.0"
 parking_lot = {version = "0.12.0", features = ["deadlock_detection"] }
+sysinfo = "0.24.2"
 tempfile = "3.2.0"
 
 pjsh_ast = { path = "../pjsh_ast" }

--- a/crates/pjsh_parse/src/parse/parser.rs
+++ b/crates/pjsh_parse/src/parse/parser.rs
@@ -468,9 +468,9 @@ impl Parser {
         let mut indent: usize = 0;
 
         if !matches!(lines.next(), Some(first_line) if first_line.is_empty()) {
-            return Err(ParseError::InvalidSyntax(format!(
-                "multiline strings must contain at least one line"
-            )));
+            return Err(ParseError::InvalidSyntax(
+                "multiline strings must contain at least one line".to_owned(),
+            ));
         }
 
         if let Some(line) = lines.next() {


### PR DESCRIPTION
Add support for lazy evaluation of environment variables.

 - Move environment scope from main binary.

 - Evaluate environment variables only when needed.