### PR TITLE
Refactor filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ dependencies = [
  "pjsh_builtins",
  "pjsh_core",
  "pjsh_eval",
+ "pjsh_filters",
  "pjsh_parse",
  "regex",
  "rustyline",
@@ -609,7 +610,6 @@ name = "pjsh_eval"
 version = "0.1.0"
 dependencies = [
  "dirs",
- "itertools",
  "os_pipe",
  "pjsh_ast",
  "pjsh_core",
@@ -617,6 +617,14 @@ dependencies = [
  "rand",
  "regex",
  "tempfile",
+]
+
+[[package]]
+name = "pjsh_filters"
+version = "0.1.0"
+dependencies = [
+ "itertools",
+ "pjsh_core",
 ]
 
 [[package]]

--- a/crates/pjsh/Cargo.toml
+++ b/crates/pjsh/Cargo.toml
@@ -19,6 +19,7 @@ rustyline-derive = "0.7"
 
 pjsh_ast = { path = "../pjsh_ast" }
 pjsh_builtins = { path = "../pjsh_builtins" }
+pjsh_filters = { path = "../pjsh_filters" }
 pjsh_core = { path = "../pjsh_core" }
 pjsh_eval = { path = "../pjsh_eval" }
 pjsh_parse = { path = "../pjsh_parse" }

--- a/crates/pjsh_ast/src/filter.rs
+++ b/crates/pjsh_ast/src/filter.rs
@@ -1,60 +1,11 @@
-use std::fmt::Display;
-
 use crate::Word;
 
 /// A value pipeline filter.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Filter {
-    // Word filters.
-    /// Transform all letters to lowercase.
-    Lower,
+pub struct Filter {
+    /// Filter name.
+    pub name: Word,
 
-    /// Replace content with something else.
-    Replace(Word, Word),
-
-    /// Transform the input to a list split by a given word.
-    Split(Word),
-
-    /// Transform all letters to uppercase.
-    Upper,
-
-    /// Return a list of all whitespace-separated words.
-    Words,
-
-    // List filters.
-    /// Return the element with the given index.
-    Index(Word),
-
-    /// Transform the input to a word joined by a given word.
-    Join(Word),
-
-    /// Return the input list length.
-    Len,
-
-    /// Reverse the input list.
-    Reverse,
-
-    /// Sort the input list.
-    Sort,
-
-    /// Return all unique elements in the input list.
-    Unique,
-}
-
-impl Display for Filter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Filter::Replace(_, _) => write!(f, "replace"),
-            Filter::Index(_) => write!(f, "index"),
-            Filter::Join(_) => write!(f, "join"),
-            Filter::Len => write!(f, "len"),
-            Filter::Lower => write!(f, "lower"),
-            Filter::Upper => write!(f, "upper"),
-            Filter::Words => write!(f, "words"),
-            Filter::Reverse => write!(f, "reverse"),
-            Filter::Sort => write!(f, "sort"),
-            Filter::Split(_) => write!(f, "split"),
-            Filter::Unique => write!(f, "unique"),
-        }
-    }
+    /// Filter arguments.
+    pub args: Vec<Word>,
 }

--- a/crates/pjsh_core/src/env/context.rs
+++ b/crates/pjsh_core/src/env/context.rs
@@ -9,8 +9,8 @@ use std::{
 use pjsh_ast::Function;
 
 use crate::{
-    command::Command, file_descriptor::FileDescriptorError, utils::word_var, FileDescriptor, Host,
-    StdHost,
+    command::Command, file_descriptor::FileDescriptorError, utils::word_var, FileDescriptor,
+    Filter, Host, StdHost,
 };
 
 /// An execution context consisting of a number of execution scopes.
@@ -26,6 +26,9 @@ pub struct Context {
 
     /// Built-in commands in the context.
     pub builtins: HashMap<String, Box<dyn Command>>,
+
+    /// Built-in filters in the context.
+    pub filters: HashMap<String, Box<dyn Filter>>,
 }
 
 impl Context {
@@ -41,6 +44,7 @@ impl Context {
             host: Arc::clone(&self.host),
             scopes,
             builtins: self.builtins.clone(),
+            filters: self.filters.clone(),
         })
     }
 
@@ -60,6 +64,7 @@ impl Context {
             host: Arc::new(parking_lot::Mutex::new(StdHost::default())),
             scopes,
             builtins: HashMap::new(),
+            filters: HashMap::new(),
         }
     }
 
@@ -330,6 +335,7 @@ impl Default for Context {
                 HashSet::default(),
             )],
             builtins: Default::default(),
+            filters: Default::default(),
         }
     }
 }

--- a/crates/pjsh_core/src/filter.rs
+++ b/crates/pjsh_core/src/filter.rs
@@ -1,0 +1,90 @@
+use std::fmt::Display;
+
+use crate::Value;
+
+/// Filter-related errors.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FilterError {
+    /// The filter cannot be applied using the provided arguments.
+    InvalidArgs(String),
+
+    /// The filter cannot be applied to lists.
+    InvalidListFilter,
+
+    /// The filter cannot be applied to words.
+    InvalidWordFilter,
+
+    /// The filter is missing a required argument.
+    MissingArg(&'static str),
+
+    /// The filter does not accept any arguments.
+    NoArgsAllowed,
+
+    /// The filter does not return a value.
+    NoSuchValue,
+
+    /// The filter has been given too many arguments.
+    TooManyArgs,
+}
+
+/// Specialized result type for filters.
+pub type FilterResult = Result<Value, FilterError>;
+
+/// A filter represents a value transformation.
+pub trait Filter: FilterClone {
+    /// Returns the filter's name.
+    fn name(&self) -> &str;
+
+    /// Returns the result of applying the filter on a list.
+    fn filter_list(&self, _list: Vec<String>, _args: &[String]) -> FilterResult {
+        Err(FilterError::InvalidListFilter)
+    }
+
+    /// Returns the result of applying the filter on a word.
+    fn filter_word(&self, _word: String, _args: &[String]) -> FilterResult {
+        Err(FilterError::InvalidWordFilter)
+    }
+}
+
+impl Display for FilterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FilterError::InvalidArgs(msg) => {
+                write!(f, "invalid arguments for filter: {msg}")
+            }
+            FilterError::InvalidListFilter => {
+                write!(f, "the filter cannot be applied to lists")
+            }
+            FilterError::InvalidWordFilter => {
+                write!(f, "the filter cannot be applied to words")
+            }
+            FilterError::MissingArg(arg) => write!(f, "missing required argument '{arg}'"),
+            FilterError::NoArgsAllowed => {
+                write!(f, "the filter does not accept any arguments")
+            }
+            FilterError::NoSuchValue => write!(f, "no such value"),
+            FilterError::TooManyArgs => write!(f, "too many arguments"),
+        }
+    }
+}
+
+/// Helper trait for making it easier to clone `Box<Command>`.
+pub trait FilterClone {
+    /// Clones the Filter into a new boxed instance.
+    fn clone_box(&self) -> Box<dyn Filter>;
+}
+
+impl<T> FilterClone for T
+where
+    T: 'static + Filter + Clone,
+{
+    fn clone_box(&self) -> Box<dyn Filter> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn Filter> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}

--- a/crates/pjsh_core/src/lib.rs
+++ b/crates/pjsh_core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod command;
 mod complete;
 mod env;
 mod file_descriptor;
+mod filter;
 mod fs;
 pub mod utils;
 
@@ -9,4 +10,5 @@ pub use complete::{Completion, Completions};
 pub use env::std_host::StdHost;
 pub use env::{context::Context, context::Scope, context::Value, host::Host};
 pub use file_descriptor::{FileDescriptor, FileDescriptorError, FD_STDERR, FD_STDIN, FD_STDOUT};
+pub use filter::{Filter, FilterError, FilterResult};
 pub use fs::{find_in_path, paths};

--- a/crates/pjsh_eval/Cargo.toml
+++ b/crates/pjsh_eval/Cargo.toml
@@ -7,7 +7,6 @@ description = "Evaluator for PJSH."
 
 [dependencies]
 dirs = "4"
-itertools = "0.10"
 os_pipe = "1"
 rand = "0.8"
 regex = "1"

--- a/crates/pjsh_eval/src/error.rs
+++ b/crates/pjsh_eval/src/error.rs
@@ -1,12 +1,13 @@
 use std::fmt::Display;
 
-use pjsh_core::FileDescriptorError;
+use pjsh_core::{FileDescriptorError, FilterError};
 
 pub type EvalResult<T> = Result<T, EvalError>;
 
 #[derive(Debug)]
 pub enum EvalError {
     FileDescriptorError(usize, FileDescriptorError),
+    FilterError(String, FilterError),
     ChildSpawnFailed(std::io::Error),
     ContextCloneFailed(std::io::Error),
     CreatePipeFailed(std::io::Error),
@@ -21,6 +22,7 @@ pub enum EvalError {
     UndefinedFunctionArguments(Vec<String>),
     UndefinedVariable(String),
     UnknownCommand(String),
+    UnknownFilter(String),
 }
 
 impl Display for EvalError {
@@ -40,6 +42,7 @@ impl Display for EvalError {
                     write!(f, "file '{}' is not writable: {err}", path.display())
                 }
             },
+            EvalError::FilterError(filter, error) => write!(f, "{filter}: {error}"),
             EvalError::ChildSpawnFailed(err) => write!(f, "failed to spawn child process: {err}"),
             EvalError::ContextCloneFailed(err) => write!(f, "failed to clone context: {err}"),
             EvalError::CreatePipeFailed(err) => write!(f, "failed to create pipe: {err}"),
@@ -60,6 +63,7 @@ impl Display for EvalError {
             }
             EvalError::UndefinedVariable(variable) => write!(f, "undefined variable: {variable}"),
             EvalError::UnknownCommand(command) => write!(f, "unknown command: {command}"),
+            EvalError::UnknownFilter(filter) => write!(f, "unknown filter: {filter}"),
         }
     }
 }

--- a/crates/pjsh_eval/src/filter.rs
+++ b/crates/pjsh_eval/src/filter.rs
@@ -1,77 +1,131 @@
-use itertools::Itertools;
 use pjsh_ast::Filter;
 use pjsh_core::{Context, Value};
-use pjsh_parse::is_whitespace;
 
 use crate::{interpolate_word, EvalError, EvalResult};
 
 /// Returns the result of applying a filter to a value.
-pub(crate) fn apply_filter(filter: &Filter, value: Value, context: &Context) -> EvalResult<Value> {
-    match (filter, value) {
-        (Filter::Index(index), Value::List(list)) => {
-            let Ok(index) = interpolate_word(index, context)?.parse::<usize>() else {
-                return Err(EvalError::InvalidIndex);
-            };
+pub(crate) fn apply_filter(
+    ast_filter: &Filter,
+    value: Value,
+    context: &Context,
+) -> EvalResult<Value> {
+    // Get the registered filter with a matching name.
+    let filter_name = interpolate_word(&ast_filter.name, context)?;
+    let Some(filter) = context.filters.get(&filter_name) else {
+        return Err(EvalError::UnknownFilter(filter_name));
+    };
 
-            list.get(index)
-                .cloned()
-                .ok_or(EvalError::InvalidIndex)
-                .map(Value::Word)
-        }
-        (Filter::Join(sep), Value::List(list)) => {
-            Ok(Value::Word(list.join(&interpolate_word(sep, context)?)))
-        }
-        (Filter::Len, Value::List(list)) => Ok(Value::Word(list.len().to_string())),
-        (Filter::Lower, Value::Word(word)) => Ok(Value::Word(word.to_lowercase())),
-        (Filter::Upper, Value::Word(word)) => Ok(Value::Word(word.to_uppercase())),
-        (Filter::Words, Value::Word(word)) => Ok(Value::List(
-            word.split(is_whitespace)
-                .filter(|s| !s.is_empty())
-                .map(ToString::to_string)
-                .collect(),
-        )),
-        (Filter::Reverse, Value::List(mut items)) => {
-            items.reverse();
-            Ok(Value::List(items))
-        }
-        (Filter::Sort, Value::List(mut items)) => {
-            items.sort();
-            Ok(Value::List(items))
-        }
-        (Filter::Split(sep), Value::Word(word)) => Ok(Value::List(
-            word.split(&interpolate_word(sep, context)?)
-                .map(ToString::to_string)
-                .collect(),
-        )),
-        (Filter::Unique, Value::List(items)) => {
-            Ok(Value::List(items.into_iter().unique().collect()))
-        }
-        (Filter::Replace(from, to), Value::Word(word)) => {
-            let from = interpolate_word(from, context)?;
-            let to = interpolate_word(to, context)?;
-            Ok(Value::Word(word.replace(&from, &to)))
-        }
-        (Filter::Replace(from, to), Value::List(items)) => {
-            let from = interpolate_word(from, context)?;
-            let to = interpolate_word(to, context)?;
-            let items = items
-                .into_iter()
-                .map(|item| if item == from { to.clone() } else { item })
-                .collect();
-            Ok(Value::List(items))
-        }
-        (filter, value) => {
-            let value_type = value_type_name(&value);
-            let message = format!("can't apply filter {filter} to value of type {value_type}");
-            Err(EvalError::InvalidValuePipeline(message))
-        }
+    // Resolve arguments after matching the filter.
+    let mut args = Vec::with_capacity(ast_filter.args.len());
+    for arg in &ast_filter.args {
+        args.push(interpolate_word(arg, context)?);
     }
+
+    // Apply the filter.
+    let result = match value {
+        Value::Word(word) => filter.filter_word(word, &args[..]),
+        Value::List(list) => filter.filter_list(list, &args[..]),
+    };
+
+    result.map_err(|error| EvalError::FilterError(filter_name, error))
 }
 
-/// Returns a value type's name.
-fn value_type_name(value: &Value) -> &str {
-    match value {
-        Value::Word(_) => "word",
-        Value::List(_) => "list",
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use pjsh_ast::Word;
+    use pjsh_core::{Filter, FilterResult};
+
+    use super::*;
+
+    #[test]
+    fn it_errors_on_unknown_filters() {
+        let unknown_filter = pjsh_ast::Filter {
+            name: Word::Literal("unknown".into()),
+            args: vec![],
+        };
+        assert!(matches!(
+            apply_filter(
+                &unknown_filter,
+                Value::Word("word".into()),
+                &Context::default(),
+            ),
+            Err(EvalError::UnknownFilter(name)) if name == "unknown"
+        ));
+    }
+
+    #[test]
+    fn it_applies_filters_to_lists() -> EvalResult<()> {
+        #[derive(Clone)]
+        struct ListFilter {
+            counter: Rc<RefCell<usize>>,
+        }
+
+        impl Filter for ListFilter {
+            fn name(&self) -> &str {
+                "listfilter"
+            }
+
+            fn filter_list(&self, list: Vec<String>, _args: &[String]) -> FilterResult {
+                *self.counter.borrow_mut() += 1;
+                Ok(Value::List(list))
+            }
+        }
+
+        let counter = Rc::new(RefCell::new(0));
+        let filter = ListFilter {
+            counter: Rc::clone(&counter),
+        };
+        let mut ctx = Context::default();
+        ctx.filters.insert(filter.name().into(), Box::new(filter));
+
+        let ast_filter = pjsh_ast::Filter {
+            name: Word::Literal("listfilter".into()),
+            args: vec![Word::Literal("arg".into())],
+        };
+
+        apply_filter(&ast_filter, Value::List(vec!["item".into()]), &ctx)?;
+
+        assert!(*counter.borrow() == 1, "the filter should be applied");
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_applies_filters_to_words() -> EvalResult<()> {
+        #[derive(Clone)]
+        struct WordFilter {
+            counter: Rc<RefCell<usize>>,
+        }
+
+        impl Filter for WordFilter {
+            fn name(&self) -> &str {
+                "wordfilter"
+            }
+
+            fn filter_word(&self, word: String, _args: &[String]) -> FilterResult {
+                *self.counter.borrow_mut() += 1;
+                Ok(Value::Word(word))
+            }
+        }
+
+        let counter = Rc::new(RefCell::new(0));
+        let filter = WordFilter {
+            counter: Rc::clone(&counter),
+        };
+        let mut ctx = Context::default();
+        ctx.filters.insert(filter.name().into(), Box::new(filter));
+
+        let ast_filter = pjsh_ast::Filter {
+            name: Word::Literal("wordfilter".into()),
+            args: vec![Word::Literal("arg".into())],
+        };
+
+        apply_filter(&ast_filter, Value::Word("word".into()), &ctx)?;
+
+        assert!(*counter.borrow() == 1, "the filter should be applied");
+
+        Ok(())
     }
 }

--- a/crates/pjsh_filters/Cargo.toml
+++ b/crates/pjsh_filters/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pjsh_filters"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Built-in filters for PJSH."
+
+[dependencies]
+itertools = "0.10"
+
+pjsh_core = { path = "../pjsh_core" }

--- a/crates/pjsh_filters/src/join.rs
+++ b/crates/pjsh_filters/src/join.rs
@@ -1,0 +1,60 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter for joining lists into words using a separator.
+#[derive(Debug, Clone)]
+pub struct JoinFilter;
+impl Filter for JoinFilter {
+    fn name(&self) -> &str {
+        "join"
+    }
+
+    fn filter_list(&self, list: Vec<String>, args: &[String]) -> FilterResult {
+        match &args {
+            [] => Err(FilterError::MissingArg("separator")),
+            [separator] => Ok(Value::Word(list.join(separator))),
+            _ => Err(FilterError::TooManyArgs),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_one_arg() {
+        assert_eq!(
+            JoinFilter.filter_list(vec!["item".into()], &[]),
+            Err(FilterError::MissingArg("separator"))
+        );
+        assert_eq!(
+            JoinFilter.filter_list(vec!["item".into()], &["1".into(), "2".into()]),
+            Err(FilterError::TooManyArgs)
+        );
+    }
+
+    #[test]
+    fn it_joins_words() -> Result<(), FilterError> {
+        let filter = JoinFilter;
+
+        assert_eq!(
+            filter.filter_list(vec!["single".into()], &[",".into()])?,
+            Value::Word("single".into())
+        );
+
+        assert_eq!(
+            filter.filter_list(vec!["first".into(), "second".into()], &[" ".into()])?,
+            Value::Word("first second".into())
+        );
+
+        assert_eq!(
+            filter.filter_list(
+                vec!["first".into(), "".into(), "third".into()],
+                &[",".into()]
+            )?,
+            Value::Word("first,,third".into())
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/len.rs
+++ b/crates/pjsh_filters/src/len.rs
@@ -1,0 +1,49 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter for returning the length of a list.
+#[derive(Debug, Clone)]
+pub struct LenFilter;
+impl Filter for LenFilter {
+    fn name(&self) -> &str {
+        "len"
+    }
+
+    fn filter_list(&self, list: Vec<String>, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        Ok(Value::Word(list.len().to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_no_args() {
+        let filter = LenFilter;
+        assert_eq!(
+            filter.filter_list(vec![], &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+    }
+
+    #[test]
+    fn it_returns_list_len() -> Result<(), FilterError> {
+        let filter = LenFilter;
+
+        assert_eq!(filter.filter_list(vec![], &[])?, Value::Word(0.to_string()));
+        assert_eq!(
+            filter.filter_list(vec!["1".into()], &[])?,
+            Value::Word(1.to_string())
+        );
+        assert_eq!(
+            filter.filter_list(vec!["1".into(), "2".into()], &[])?,
+            Value::Word(2.to_string())
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/lib.rs
+++ b/crates/pjsh_filters/src/lib.rs
@@ -1,0 +1,23 @@
+mod join;
+mod len;
+mod lines;
+mod list_items;
+mod replace;
+mod reverse;
+mod sort;
+mod split;
+mod text_case;
+mod unique;
+mod words;
+
+pub use join::JoinFilter;
+pub use len::LenFilter;
+pub use lines::LinesFilter;
+pub use list_items::{FirstFilter, LastFilter, NthFilter};
+pub use replace::ReplaceFilter;
+pub use reverse::ReverseFilter;
+pub use sort::SortFilter;
+pub use split::SplitFilter;
+pub use text_case::{LowercaseFilter, UcfirstFilter, UppercaseFilter};
+pub use unique::UniqueFilter;
+pub use words::WordsFilter;

--- a/crates/pjsh_filters/src/lines.rs
+++ b/crates/pjsh_filters/src/lines.rs
@@ -1,0 +1,49 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter for separating words into lists based on lines.
+///
+/// Lines are ended with either a newline (`\n`) or a carriage return with
+/// a line feed (`\r\n`).
+#[derive(Debug, Clone)]
+pub struct LinesFilter;
+impl Filter for LinesFilter {
+    fn name(&self) -> &str {
+        "lines"
+    }
+
+    fn filter_word(&self, word: String, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        Ok(Value::List(word.lines().map(ToString::to_string).collect()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_no_args() {
+        let filter = LinesFilter;
+        assert_eq!(
+            filter.filter_word("word".into(), &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+    }
+
+    #[test]
+    fn it_returns_lines() -> Result<(), FilterError> {
+        let filter = LinesFilter;
+
+        assert_eq!(filter.filter_word("".into(), &[])?, Value::List(vec![]));
+
+        assert_eq!(
+            filter.filter_word("a\nb\r\nc".into(), &[])?,
+            Value::List(vec!["a".into(), "b".into(), "c".into()])
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/list_items.rs
+++ b/crates/pjsh_filters/src/list_items.rs
@@ -1,0 +1,178 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter that returns the first word in a list.
+#[derive(Debug, Clone)]
+pub struct FirstFilter;
+impl Filter for FirstFilter {
+    fn name(&self) -> &str {
+        "first"
+    }
+
+    fn filter_list(&self, list: Vec<String>, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        let Some(item) = list.into_iter().next() else {
+            return Err(FilterError::NoSuchValue);
+        };
+
+        Ok(Value::Word(item))
+    }
+}
+
+/// A filter that returns the last word in a list.
+#[derive(Debug, Clone)]
+pub struct LastFilter;
+impl Filter for LastFilter {
+    fn name(&self) -> &str {
+        "last"
+    }
+
+    fn filter_list(&self, list: Vec<String>, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        let Some(item) = list.into_iter().last() else {
+            return Err(FilterError::NoSuchValue);
+        };
+
+        Ok(Value::Word(item))
+    }
+}
+
+/// A filter that returns the `n`-th word in a list.
+#[derive(Debug, Clone)]
+pub struct NthFilter;
+impl Filter for NthFilter {
+    fn name(&self) -> &str {
+        "nth"
+    }
+
+    fn filter_list(&self, list: Vec<String>, args: &[String]) -> FilterResult {
+        let n = match &args {
+            [] => return Err(FilterError::MissingArg("index")),
+            [n] => match n.parse::<usize>() {
+                Ok(n) => n,
+                Err(err) => return Err(FilterError::InvalidArgs(format!("invalid index: {err}"))),
+            },
+            _ => return Err(FilterError::TooManyArgs),
+        };
+
+        let Some(item) = list.into_iter().nth(n) else {
+            return Err(FilterError::NoSuchValue);
+        };
+
+        Ok(Value::Word(item))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_args() {
+        assert_eq!(
+            NthFilter.filter_list(vec!["item".into()], &[]),
+            Err(FilterError::MissingArg("index"))
+        );
+        assert_eq!(
+            NthFilter.filter_list(vec!["item".into()], &["1".into(), "2".into()]),
+            Err(FilterError::TooManyArgs)
+        );
+
+        assert_eq!(
+            FirstFilter.filter_list(vec!["item".into()], &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+
+        assert_eq!(
+            LastFilter.filter_list(vec!["item".into()], &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+    }
+
+    #[test]
+    fn it_returns_the_nth_item() -> Result<(), FilterError> {
+        assert_eq!(
+            NthFilter.filter_list(vec!["single".into()], &["0".into()])?,
+            Value::Word("single".into())
+        );
+        assert_eq!(
+            NthFilter.filter_list(vec!["single".into()], &["1".into()]),
+            Err(FilterError::NoSuchValue)
+        );
+
+        assert_eq!(
+            NthFilter.filter_list(vec!["first".into(), "second".into()], &["1".into()])?,
+            Value::Word("second".into())
+        );
+
+        assert_eq!(
+            NthFilter.filter_list(
+                vec!["first".into(), "".into(), "third".into()],
+                &["2".into()]
+            )?,
+            Value::Word("third".into())
+        );
+
+        assert!(matches!(
+            NthFilter.filter_list(vec!["first".into(), "second".into()], &["n".into()]),
+            Err(FilterError::InvalidArgs(_))
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_returns_the_first_item() -> Result<(), FilterError> {
+        assert_eq!(
+            FirstFilter.filter_list(vec![], &[]),
+            Err(FilterError::NoSuchValue)
+        );
+
+        assert_eq!(
+            FirstFilter.filter_list(vec!["single".into()], &[])?,
+            Value::Word("single".into())
+        );
+
+        assert_eq!(
+            FirstFilter.filter_list(vec!["first".into(), "second".into()], &[])?,
+            Value::Word("first".into())
+        );
+
+        assert_eq!(
+            FirstFilter.filter_list(vec!["first".into(), "second".into(), "third".into()], &[])?,
+            Value::Word("first".into())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_returns_the_last_item() -> Result<(), FilterError> {
+        assert_eq!(
+            LastFilter.filter_list(vec![], &[]),
+            Err(FilterError::NoSuchValue)
+        );
+
+        assert_eq!(
+            LastFilter.filter_list(vec!["single".into()], &[])?,
+            Value::Word("single".into())
+        );
+
+        assert_eq!(
+            LastFilter.filter_list(vec!["first".into(), "second".into()], &[])?,
+            Value::Word("second".into())
+        );
+
+        assert_eq!(
+            LastFilter.filter_list(vec!["first".into(), "second".into(), "third".into()], &[])?,
+            Value::Word("third".into())
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/replace.rs
+++ b/crates/pjsh_filters/src/replace.rs
@@ -1,0 +1,106 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter that replaces values.
+///
+/// For lists, the filter replaces entire words.
+///
+/// For words, the filter replaces character patterns.
+#[derive(Debug, Clone)]
+pub struct ReplaceFilter;
+impl Filter for ReplaceFilter {
+    fn name(&self) -> &str {
+        "replace"
+    }
+
+    fn filter_list(&self, list: Vec<String>, args: &[String]) -> FilterResult {
+        let (from, to) = match &args {
+            [] => return Err(FilterError::MissingArg("from")),
+            [_] => return Err(FilterError::MissingArg("to")),
+            [from, to] => (from, to),
+            _ => return Err(FilterError::TooManyArgs),
+        };
+
+        let list = list
+            .into_iter()
+            .map(|item| if &item == from { to.to_string() } else { item })
+            .collect();
+
+        Ok(Value::List(list))
+    }
+
+    fn filter_word(&self, word: String, args: &[String]) -> FilterResult {
+        let (from, to) = match &args {
+            [] => return Err(FilterError::MissingArg("from")),
+            [_] => return Err(FilterError::MissingArg("to")),
+            [from, to] => (from, to),
+            _ => return Err(FilterError::TooManyArgs),
+        };
+
+        Ok(Value::Word(word.replace(from, to)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_two_args() {
+        let filter = ReplaceFilter;
+        assert_eq!(
+            filter.filter_list(vec!["item".into()], &[]),
+            Err(FilterError::MissingArg("from"))
+        );
+        assert_eq!(
+            filter.filter_list(vec!["item".into()], &["from".into()]),
+            Err(FilterError::MissingArg("to"))
+        );
+        assert_eq!(
+            filter.filter_list(
+                vec!["item".into()],
+                &["from".into(), "to".into(), "extra".into()]
+            ),
+            Err(FilterError::TooManyArgs)
+        );
+
+        assert_eq!(
+            filter.filter_word("word".into(), &[]),
+            Err(FilterError::MissingArg("from"))
+        );
+        assert_eq!(
+            filter.filter_word("word".into(), &["from".into()]),
+            Err(FilterError::MissingArg("to"))
+        );
+        assert_eq!(
+            filter.filter_word("word".into(), &["from".into(), "to".into(), "extra".into()]),
+            Err(FilterError::TooManyArgs)
+        );
+    }
+
+    #[test]
+    fn it_replaces_list_items() -> Result<(), FilterError> {
+        let filter = ReplaceFilter;
+
+        assert_eq!(
+            filter.filter_list(
+                vec!["a".into(), "b".into(), "c".into()],
+                &["a".into(), "b".into()]
+            )?,
+            Value::List(vec!["b".into(), "b".into(), "c".into()])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_replaces_word_chars() -> Result<(), FilterError> {
+        let filter = ReplaceFilter;
+
+        assert_eq!(
+            filter.filter_word("abc".into(), &["b".into(), "c".into()])?,
+            Value::Word("acc".into()),
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/reverse.rs
+++ b/crates/pjsh_filters/src/reverse.rs
@@ -1,0 +1,44 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter that reverses lists.
+#[derive(Debug, Clone)]
+pub struct ReverseFilter;
+impl Filter for ReverseFilter {
+    fn name(&self) -> &str {
+        "reverse"
+    }
+
+    fn filter_list(&self, mut list: Vec<String>, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        list.reverse();
+        Ok(Value::List(list))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_no_args() {
+        assert_eq!(
+            ReverseFilter.filter_list(vec!["item".into()], &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+    }
+
+    #[test]
+    fn it_reverses_lists() -> Result<(), FilterError> {
+        let filter = ReverseFilter;
+
+        assert_eq!(
+            filter.filter_list(vec!["a".into(), "b".into(), "c".into()], &[])?,
+            Value::List(vec!["c".into(), "b".into(), "a".into()])
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/sort.rs
+++ b/crates/pjsh_filters/src/sort.rs
@@ -1,0 +1,44 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter that sorts lists.
+#[derive(Debug, Clone)]
+pub struct SortFilter;
+impl Filter for SortFilter {
+    fn name(&self) -> &str {
+        "sort"
+    }
+
+    fn filter_list(&self, mut list: Vec<String>, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        list.sort_unstable();
+        Ok(Value::List(list))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_no_args() {
+        assert_eq!(
+            SortFilter.filter_list(vec!["item".into()], &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+    }
+
+    #[test]
+    fn it_sorts_lists() -> Result<(), FilterError> {
+        let filter = SortFilter;
+
+        assert_eq!(
+            filter.filter_list(vec!["c".into(), "a".into(), "c".into()], &[])?,
+            Value::List(vec!["a".into(), "c".into(), "c".into()])
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/split.rs
+++ b/crates/pjsh_filters/src/split.rs
@@ -1,0 +1,62 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter that splits words into lists using a separator.
+#[derive(Debug, Clone)]
+pub struct SplitFilter;
+impl Filter for SplitFilter {
+    fn name(&self) -> &str {
+        "split"
+    }
+
+    fn filter_word(&self, word: String, args: &[String]) -> FilterResult {
+        match &args {
+            [] => Err(FilterError::MissingArg("separator")),
+            [separator] => Ok(Value::List(
+                word.split(separator)
+                    .into_iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )),
+            _ => Err(FilterError::TooManyArgs),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_one_arg() {
+        assert_eq!(
+            SplitFilter.filter_word("word".into(), &[]),
+            Err(FilterError::MissingArg("separator"))
+        );
+        assert_eq!(
+            SplitFilter.filter_word("word".into(), &["1".into(), "2".into()]),
+            Err(FilterError::TooManyArgs)
+        );
+    }
+
+    #[test]
+    fn it_splits_words() -> Result<(), FilterError> {
+        let filter = SplitFilter;
+
+        assert_eq!(
+            filter.filter_word("single".into(), &["sep".into()])?,
+            Value::List(vec!["single".into()])
+        );
+
+        assert_eq!(
+            filter.filter_word("first,second".into(), &[",".into()])?,
+            Value::List(vec!["first".into(), "second".into()])
+        );
+
+        assert_eq!(
+            filter.filter_word("first,,third".into(), &[",".into()])?,
+            Value::List(vec!["first".into(), "".into(), "third".into()])
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/text_case.rs
+++ b/crates/pjsh_filters/src/text_case.rs
@@ -1,0 +1,117 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter that converts words into lowercase.
+#[derive(Debug, Clone)]
+pub struct LowercaseFilter;
+impl Filter for LowercaseFilter {
+    fn name(&self) -> &str {
+        "lowercase"
+    }
+
+    fn filter_word(&self, word: String, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        Ok(Value::Word(word.to_lowercase()))
+    }
+}
+
+/// A filter that converts words into uppercase.
+#[derive(Debug, Clone)]
+pub struct UppercaseFilter;
+impl Filter for UppercaseFilter {
+    fn name(&self) -> &str {
+        "uppercase"
+    }
+
+    fn filter_word(&self, word: String, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        Ok(Value::Word(word.to_uppercase()))
+    }
+}
+
+/// A filter that converts the first letter of words into uppercase.
+#[derive(Debug, Clone)]
+pub struct UcfirstFilter;
+impl Filter for UcfirstFilter {
+    fn name(&self) -> &str {
+        "ucfirst"
+    }
+
+    fn filter_word(&self, word: String, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        let mut chars = word.chars();
+        let Some(first) = chars.next() else {
+            return Ok(Value::Word(String::new()));
+        };
+
+        let word = first.to_uppercase().to_string() + chars.as_str();
+        Ok(Value::Word(word))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_no_args() {
+        assert_eq!(
+            LowercaseFilter.filter_word("word".into(), &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+        assert_eq!(
+            UcfirstFilter.filter_word("word".into(), &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+        assert_eq!(
+            UppercaseFilter.filter_word("word".into(), &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+    }
+
+    #[test]
+    fn it_converts_chars_to_lowercase() -> Result<(), FilterError> {
+        assert_eq!(
+            LowercaseFilter.filter_word("aBcÅäÖ".into(), &[])?,
+            Value::Word("abcåäö".into()),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_converts_chars_to_uppercase() -> Result<(), FilterError> {
+        assert_eq!(
+            UppercaseFilter.filter_word("aBcÅäÖ".into(), &[])?,
+            Value::Word("ABCÅÄÖ".into()),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_converts_first_char_to_uppercase() -> Result<(), FilterError> {
+        assert_eq!(
+            UcfirstFilter.filter_word("".into(), &[])?,
+            Value::Word("".into()),
+        );
+        assert_eq!(
+            UcfirstFilter.filter_word("abc".into(), &[])?,
+            Value::Word("Abc".into()),
+        );
+        assert_eq!(
+            UcfirstFilter.filter_word("åäö".into(), &[])?,
+            Value::Word("Åäö".into()),
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/unique.rs
+++ b/crates/pjsh_filters/src/unique.rs
@@ -1,0 +1,44 @@
+use itertools::Itertools;
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter that removes duplicate values from lists.
+#[derive(Debug, Clone)]
+pub struct UniqueFilter;
+impl Filter for UniqueFilter {
+    fn name(&self) -> &str {
+        "unique"
+    }
+
+    fn filter_list(&self, list: Vec<String>, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        Ok(Value::List(list.into_iter().unique().collect()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_no_args() {
+        assert_eq!(
+            UniqueFilter.filter_list(vec!["item".into()], &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+    }
+
+    #[test]
+    fn it_removes_duplicated_list_items() -> Result<(), FilterError> {
+        let filter = UniqueFilter;
+
+        assert_eq!(
+            filter.filter_list(vec!["a".into(), "b".into(), "a".into()], &[])?,
+            Value::List(vec!["a".into(), "b".into()])
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_filters/src/words.rs
+++ b/crates/pjsh_filters/src/words.rs
@@ -1,0 +1,53 @@
+use pjsh_core::{Filter, FilterError, FilterResult, Value};
+
+/// A filter for separating words into lists based on lines.
+///
+/// Empty words are removed.
+#[derive(Debug, Clone)]
+pub struct WordsFilter;
+impl Filter for WordsFilter {
+    fn name(&self) -> &str {
+        "words"
+    }
+
+    fn filter_word(&self, word: String, args: &[String]) -> FilterResult {
+        if !args.is_empty() {
+            return Err(FilterError::NoArgsAllowed);
+        }
+
+        let words = word
+            .split(char::is_whitespace)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .collect();
+
+        Ok(Value::List(words))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_accepts_no_args() {
+        assert_eq!(
+            WordsFilter.filter_word("word".into(), &["not-allowed".into()]),
+            Err(FilterError::NoArgsAllowed)
+        );
+    }
+
+    #[test]
+    fn it_returns_words() -> Result<(), FilterError> {
+        let filter = WordsFilter;
+
+        assert_eq!(filter.filter_word("".into(), &[])?, Value::List(vec![]));
+
+        assert_eq!(
+            filter.filter_word("a b\tc\nd".into(), &[])?,
+            Value::List(vec!["a".into(), "b".into(), "c".into(), "d".into()])
+        );
+
+        Ok(())
+    }
+}

--- a/crates/pjsh_parse/src/parse/word.rs
+++ b/crates/pjsh_parse/src/parse/word.rs
@@ -302,7 +302,10 @@ mod tests {
             ])),
             Ok(Word::ValuePipeline(Box::new(ValuePipeline {
                 base: "base".into(),
-                filters: vec![Filter::Sort],
+                filters: vec![Filter {
+                    name: Word::Literal("sort".into()),
+                    args: vec![]
+                }],
             })))
         );
     }

--- a/doc/src/filtering.md
+++ b/doc/src/filtering.md
@@ -5,28 +5,28 @@ Variable-based values may be manipulated in _value pipelines_ using _filters_.
 The syntax for value pipelines is as follows:
 
 ```pjsh
-items = [2 1 4 3]
+items := [2 1 4 3]
 echo ${items | sort | join ", "}
 ```
 
-## Word filters
+## Filters
 
-The following filters can be applied to words:
+The following built-in filters are provided:
 
-| Filter    | Return type | Description                                          |
-| :-------- | :---------- | :--------------------------------------------------- |
-| `lower`   | Word        | Converts the input word to all lowercase characters. |
-| `split c` | List        | Splits the input on all `c` characters.              |
-| `upper`   | Word        | Converts the input word to all uppercase characters. |
-
-## List filters
-
-The following filters can be applied to lists:
-
-| Filter    | Return type | Description                               |
-| :-------- | :---------- | :---------------------------------------- |
-| `index i` | Word        | Returns the `i`-th item in the input.     |
-| `len`     | Word        | Returns the number of items in the input. |
-| `reverse` | List        | Reverses the input.                       |
-| `sort`    | List        | Sorts the input.                          |
-| `unique`  | List        | Removes duplicate values from the input.  |
+| Filter            | Input type | Return type   | Description                                                       |
+| :---------------- | :--------- | :------------ | :---------------------------------------------------------------- |
+| `first`           | List       | Word          | Returns the first item in a list.                                 |
+| `join sep`        | List       | Word          | Joins a list using a word separator.                              |
+| `last`            | List       | Word          | Returns the last item in a list.                                  |
+| `len`             | List       | Word          | Returns the length of a list.                                     |
+| `lines`           | Word       | List          | Splits a word into a list of lines (separated by `\n` or `\r\n`). |
+| `lowercase`       | Word       | Word          | Converts all characters into lowercase.                           |
+| `nth n`           | List       | Word          | Returns the `n`-th item in a list.                                |
+| `replace from to` | Word, List | Same as input | Replaces a value in a list or word.                               |
+| `reverse`         | List       | List          | Reverses a list.                                                  |
+| `sort`            | List       | List          | Sorts a list.                                                     |
+| `split sep`       | Word       | List          | Splits a word into a list using a word separator.                 |
+| `ucfirst`         | Word       | Word          | Converts the first character into uppercase.                      |
+| `unique`          | List       | List          | Removes duplicate items from a list.                              |
+| `uppercase`       | Word       | Word          | Converts all characters into uppercase.                           |
+| `words`           | Word       | List          | Returns a list of whitespace-separated words.                     |


### PR DESCRIPTION
Rewrite filters into a separate crate.

 - Move filters into their own crate.
 - Separate filter functionality from parsing and the AST.
 - Allow filter implementations to be tested in isolation.
 - Add filter tests.
 - Update filter-related documentation.