### PR TITLE
Optimize release binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,6 @@ members = [
 ]
 
 [profile.release]
+codegen-units = 1
 lto = true
+strip = true


### PR DESCRIPTION
Update the release configuration.

 - Restrict codegen units. This trades improved optimization for increased build times.

 - Strip the binary.